### PR TITLE
Add API Key Setup to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,20 @@ poetry install
 ```
 
 ## Run examples
-
 You can run the examples in the `examples/` directory using `poetry run` or by entering the virtual environment using `poetry shell`.
+
+### API Key Setup
+Running the examples requires a Mistral AI API key.
+
+1. Get your own Mistral API Key: https://docs.mistral.ai/#api-access
+2. Set your Mistral API Key as an environment variable. You only need to do this once. 
+```bash
+# set Mistral API Key (using zsh for example)
+$ echo 'export MISTRAL_API_KEY=[your_key_here]' >> ~/.zshenv
+
+# reload the environment (or just quit and open a new terminal)
+$ source ~/.zshenv
+```
 
 ### Using poetry run
 


### PR DESCRIPTION
Add API key setup required to run the examples + provide zshenv setup example. 