### PR TITLE
Fix client_base.py Logging to Prevent Conflicts

### DIFF
--- a/src/mistralai/client_base.py
+++ b/src/mistralai/client_base.py
@@ -14,10 +14,16 @@ from mistralai.exceptions import (
 )
 from mistralai.models.chat_completion import ChatMessage
 
-logging.basicConfig(
-    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-    level=os.getenv("LOG_LEVEL", "ERROR"),
-)
+logger = logging.getLogger("mistralai")
+
+log_formatter = logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+
+stream_handler = logging.StreamHandler()
+stream_handler.setFormatter(log_formatter)
+
+logger.addHandler(stream_handler)
+
+logger.setLevel(os.getenv("LOG_LEVEL", "ERROR"))
 
 
 class ClientBase(ABC):


### PR DESCRIPTION
Before this update, invoking logging.basicConfig within client_base.py directly altered the global (root) logging configuration. This modification had several unintended effects on any project importing mistralai. Specifically, it caused each custom logger within these projects to inadvertently inherit a handler from the root logger. The result was potential duplicate log entries and interference with the intended logging configurations of these projects.

To address this issue, the refactor eliminates the direct call to logging.basicConfig. Instead, we now explicitly create a logger named "mistralai." By using `__name__` as the argument in the `logging.getLogger` function, and considering the placement of this file within the "mistralai" directory, we ensure that the "mistralai" logger acts as the parent for any logger derived from this module. This change leverages Python's logging hierarchy to isolate mistralai's logging configuration, avoiding the alteration of the global logging setup.