### PR TITLE
fix: get api key at client initialisation:

### DIFF
--- a/src/mistralai/async_client.py
+++ b/src/mistralai/async_client.py
@@ -33,7 +33,7 @@ from mistralai.models.models import ModelList
 class MistralAsyncClient(ClientBase):
     def __init__(
         self,
-        api_key: Optional[str] = os.environ.get("MISTRAL_API_KEY", None),
+        api_key: Optional[str] = None,
         endpoint: str = ENDPOINT,
         max_retries: int = 5,
         timeout: int = 120,

--- a/src/mistralai/client.py
+++ b/src/mistralai/client.py
@@ -30,7 +30,7 @@ class MistralClient(ClientBase):
 
     def __init__(
         self,
-        api_key: Optional[str] = os.environ.get("MISTRAL_API_KEY", None),
+        api_key: Optional[str] = None,
         endpoint: str = ENDPOINT,
         max_retries: int = 5,
         timeout: int = 120,

--- a/src/mistralai/client_base.py
+++ b/src/mistralai/client_base.py
@@ -31,8 +31,14 @@ class ClientBase(ABC):
         self._max_retries = max_retries
         self._timeout = timeout
 
-        self._endpoint = endpoint
+        if api_key is None:
+            api_key = os.environ.get("MISTRAL_API_KEY")
+        if api_key is None:
+            raise MistralException(
+                message="API key not provided. Please set MISTRAL_API_KEY environment variable."
+            )
         self._api_key = api_key
+        self._endpoint = endpoint
         self._logger = logging.getLogger(__name__)
 
         # This should be automatically updated by the deploy script


### PR DESCRIPTION
Currently, it's done at interpretation time, disallowing environment modification.

I also added an Exception instead of going all the way to triggering a request that will invariably come back "unauthorized".

Note: I took the liberty to move the shared init logic to the base client, not sure if that goes in the direction that you guys have in mind.