### PR TITLE
Remove HttpTransport from Client initialization

### DIFF
--- a/src/mistralai/client.py
+++ b/src/mistralai/client.py
@@ -4,7 +4,7 @@ import time
 from json import JSONDecodeError
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Union
 
-from httpx import Client, ConnectError, HTTPTransport, RequestError, Response
+from httpx import Client, ConnectError, RequestError, Response
 
 from mistralai.client_base import ClientBase
 from mistralai.constants import ENDPOINT, RETRY_STATUS_CODES
@@ -39,7 +39,7 @@ class MistralClient(ClientBase):
         super().__init__(endpoint, api_key, max_retries, timeout)
 
         self._client = Client(
-            follow_redirects=True, timeout=self._timeout, transport=HTTPTransport(retries=self._max_retries)
+            follow_redirects=True, timeout=self._timeout
         )
 
     def __del__(self) -> None:


### PR DESCRIPTION
Initializing HttpTransport disables using proxies defined in the environment which is a bit unexpected.

https://github.com/encode/httpx/blob/392dbe45f086d0877bd288c5d68abf860653b680/httpx/_client.py#L1440

The question is whether we need max_retries in HttpTransport. Does it really do anything?