### PR TITLE
Remove setting of the _root_ logger level as this is best done by the…

### DIFF
--- a/src/mistralai/client_base.py
+++ b/src/mistralai/client_base.py
@@ -10,11 +10,6 @@ from mistralai.exceptions import (
 )
 from mistralai.models.chat_completion import ChatMessage, Function, ResponseFormat, ToolChoice
 
-logging.basicConfig(
-    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-    level=os.getenv("LOG_LEVEL", "ERROR"),
-)
-
 
 class ClientBase(ABC):
     def __init__(


### PR DESCRIPTION
As I understand it: The root logger should not be changed by a library. The reason for this is that now anyone using Mistral Client will have their root logger changed and log statements in the calling code will be affected (both by the level and the formatting). This behavior can be seen by the following snippet:

```
import logging

# from mistralai.client import MistralClient

logger = logging.getLogger(__name__)
logger.warning("hi")
```

The logger warning will only be displayed if the second line is commented, because otherwise the log level will be set to ERROR.

The suggested solution is to leave the formatting and level to the end user (calling code) and remove it from here.