### PR TITLE
Add tool call id for new models with v3 tokenization

### DIFF
--- a/examples/function_calling.py
+++ b/examples/function_calling.py
@@ -64,7 +64,7 @@ tools = [
 ]
 
 api_key = os.environ["MISTRAL_API_KEY"]
-model = "mistral-large-latest"
+model = "mistral-small-latest"
 
 client = MistralClient(api_key=api_key)
 
@@ -90,7 +90,7 @@ print(f"calling function_name: {function_name}, with function_params: {function_
 function_result = names_to_functions[function_name](**function_params)
 
 messages.append(response.choices[0].message)
-messages.append(ChatMessage(role="tool", name=function_name, content=function_result))
+messages.append(ChatMessage(role="tool", name=function_name, content=function_result, tool_call_id=tool_call.id))
 
 response = client.chat(model=model, messages=messages, tools=tools)
 

--- a/src/mistralai/models/chat_completion.py
+++ b/src/mistralai/models/chat_completion.py
@@ -47,6 +47,7 @@ class ChatMessage(BaseModel):
     content: Union[str, List[str]]
     name: Optional[str] = None
     tool_calls: Optional[List[ToolCall]] = None
+    tool_call_id: Optional[str] = None
 
 
 class DeltaMessage(BaseModel):


### PR DESCRIPTION
The following models have now support for multiple tool calls and therefore need a tool call id in the tool message to be able to identify which tool call is linked to which tool response:

* mistral-small-2402
* open-mixtral-8x22b
* open-mistral-7b