### PR TITLE
Fix docstring for stop parameter in completion method

### DIFF
--- a/src/mistralai/client.py
+++ b/src/mistralai/client.py
@@ -308,7 +308,7 @@ class MistralClient(ClientBase):
             top_p (Optional[float], optional): the cumulative probability of tokens to generate, e.g. 0.9.
             Defaults to None.
             random_seed (Optional[int], optional): the random seed to use for sampling, e.g. 42. Defaults to None.
-            stop (Optional[List[str]], optional): a list of tokens to stop generation at, e.g. ['/n/n']
+            stop (Optional[List[str]], optional): a list of tokens to stop generation at, e.g. ['\n\n']
 
         Returns:
             Dict[str, Any]: a response object containing the generated text.


### PR DESCRIPTION
Corrected the representation of newline characters in the `stop` parameter example of the `completion` method docstring.

- Updated the example from `'/n/n'` to `'\n\n'` to accurately represent double newlines.
- This change ensures clarity and correctness, making it clear for users how to specify newline characters as stop tokens.
- The correct representation of newlines is crucial for the proper functioning of text generation tasks.