### PR TITLE
fix: Remove redundant LOG_FORMAT definition

### DIFF
--- a/examples/chatbot_with_streaming.py
+++ b/examples/chatbot_with_streaming.py
@@ -32,8 +32,6 @@ COMMAND_LIST = {
     "/exit": {},
 }
 
-LOG_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"
-
 logger = logging.getLogger("chatbot")
 
 


### PR DESCRIPTION
Removed the second instance of the LOG_FORMAT definition in the chatbot script. The specific change was the removal of the line LOG_FORMAT = "%(asctime)s - %(levelname)s - %(message)s" which appeared twice consecutively. This correction helps maintain code clarity and conciseness.