### PR TITLE
fix dependencies specification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,10 @@ exclude = ["docs", "tests", "examples", "tools", "build"]
 
 
 [tool.poetry.dependencies]
-python = "^3.9,<4.0"
-orjson = "^3.9.10,<3.11"
-pydantic = "^2.5.2,<3"
-httpx = "^0.25,<1"
+python = "^3.9"
+orjson = ">=3.9.10,<3.11"
+pydantic = "^2.5.2"
+httpx = ">=0.25,<1"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
The current dependency section doesn't work as expected and actually breaks dependencies for users of poetry.

See https://python-poetry.org/docs/dependency-specification/#version-constraints

Notably for `httpx`: any user who wants to use a package that requires a recent version of httpx will be left in a hell of "version solving failed" because the semver used actually limits to `<=0.26.0` (instead of the 1.0.0 which was the intent but poorly specificied).

Note: I kept `^` specification when relevant, but we might want to use `>= , <` everywhere instead to be more consistent.