### PR TITLE
feat/model deletion

### DIFF
--- a/examples/async_jobs_chat.py
+++ b/examples/async_jobs_chat.py
@@ -54,6 +54,9 @@ async def main():
     await client.files.delete(training_file.id)
     await client.files.delete(validation_file.id)
 
+    # Delete fine-tuned model
+    await client.delete_model(created_job.fine_tuned_model)
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mistralai"
-version = "0.4.0"
+version = "0.4.1"
 description = ""
 authors = ["Bam4d <bam4d@mistral.ai>"]
 readme = "README.md"

--- a/src/mistralai/async_client.py
+++ b/src/mistralai/async_client.py
@@ -29,7 +29,7 @@ from mistralai.models.chat_completion import (
     ToolChoice,
 )
 from mistralai.models.embeddings import EmbeddingResponse
-from mistralai.models.models import ModelList
+from mistralai.models.models import ModelList, ModelDeleted
 
 
 class MistralAsyncClient(ClientBase):
@@ -301,6 +301,14 @@ class MistralAsyncClient(ClientBase):
 
         async for response in single_response:
             return ModelList(**response)
+
+        raise MistralException("No response received")
+
+    async def delete_model(self, model_id: str) -> ModelDeleted:
+        single_response = self._request("delete", {}, f"v1/models/{model_id}")
+
+        async for response in single_response:
+            return ModelDeleted(**response)
 
         raise MistralException("No response received")
 

--- a/src/mistralai/async_client.py
+++ b/src/mistralai/async_client.py
@@ -29,7 +29,7 @@ from mistralai.models.chat_completion import (
     ToolChoice,
 )
 from mistralai.models.embeddings import EmbeddingResponse
-from mistralai.models.models import ModelList, ModelDeleted
+from mistralai.models.models import ModelDeleted, ModelList
 
 
 class MistralAsyncClient(ClientBase):

--- a/src/mistralai/client.py
+++ b/src/mistralai/client.py
@@ -22,7 +22,7 @@ from mistralai.models.chat_completion import (
     ToolChoice,
 )
 from mistralai.models.embeddings import EmbeddingResponse
-from mistralai.models.models import ModelList, ModelDeleted
+from mistralai.models.models import ModelDeleted, ModelList
 
 
 class MistralClient(ClientBase):

--- a/src/mistralai/client.py
+++ b/src/mistralai/client.py
@@ -22,7 +22,7 @@ from mistralai.models.chat_completion import (
     ToolChoice,
 )
 from mistralai.models.embeddings import EmbeddingResponse
-from mistralai.models.models import ModelList
+from mistralai.models.models import ModelList, ModelDeleted
 
 
 class MistralClient(ClientBase):
@@ -295,6 +295,14 @@ class MistralClient(ClientBase):
 
         for response in singleton_response:
             return ModelList(**response)
+
+        raise MistralException("No response received")
+
+    def delete_model(self, model_id: str) -> ModelDeleted:
+        single_response = self._request("delete", {}, f"v1/models/{model_id}")
+
+        for response in single_response:
+            return ModelDeleted(**response)
 
         raise MistralException("No response received")
 

--- a/src/mistralai/client_base.py
+++ b/src/mistralai/client_base.py
@@ -10,7 +10,7 @@ from mistralai.exceptions import (
 )
 from mistralai.models.chat_completion import ChatMessage, Function, ResponseFormat, ToolChoice
 
-CLIENT_VERSION = "0.4.0"
+CLIENT_VERSION = "0.4.1"
 
 
 class ClientBase(ABC):

--- a/src/mistralai/models/models.py
+++ b/src/mistralai/models/models.py
@@ -31,3 +31,9 @@ class ModelCard(BaseModel):
 class ModelList(BaseModel):
     object: str
     data: List[ModelCard]
+
+
+class ModelDeleted(BaseModel):
+    id: str
+    object: str
+    deleted: bool

--- a/tests/test_delete_model.py
+++ b/tests/test_delete_model.py
@@ -1,0 +1,27 @@
+from mistralai.models.models import ModelDeleted
+
+from .utils import mock_response, mock_model_deleted_response_payload
+
+
+class TestDeleteModel:
+    def test_delete_model(self, client):
+        expected_response_model = ModelDeleted.model_validate_json(mock_model_deleted_response_payload())
+        client._client.request.return_value = mock_response(200, expected_response_model.json())
+
+        response_model = client.delete_model("model_id")
+
+        client._client.request.assert_called_once_with(
+            "delete",
+            "https://api.mistral.ai/v1/models/model_id",
+            headers={
+                "User-Agent": f"mistral-client-python/{client._version}",
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                "Authorization": "Bearer test_api_key",
+            },
+            json={},
+            data=None,
+        )
+
+        assert response_model == expected_response_model
+

--- a/tests/test_delete_model.py
+++ b/tests/test_delete_model.py
@@ -24,4 +24,3 @@ class TestDeleteModel:
         )
 
         assert response_model == expected_response_model
-

--- a/tests/test_delete_model.py
+++ b/tests/test_delete_model.py
@@ -1,6 +1,6 @@
 from mistralai.models.models import ModelDeleted
 
-from .utils import mock_response, mock_model_deleted_response_payload
+from .utils import mock_model_deleted_response_payload, mock_response
 
 
 class TestDeleteModel:

--- a/tests/test_delete_model_async.py
+++ b/tests/test_delete_model_async.py
@@ -1,8 +1,7 @@
 import pytest
-
 from mistralai.models.models import ModelDeleted
 
-from .utils import mock_response, mock_model_deleted_response_payload
+from .utils import mock_model_deleted_response_payload, mock_response
 
 
 class TestAsyncDeleteModel:

--- a/tests/test_delete_model_async.py
+++ b/tests/test_delete_model_async.py
@@ -1,0 +1,30 @@
+import pytest
+
+from mistralai.models.models import ModelDeleted
+
+from .utils import mock_response, mock_model_deleted_response_payload
+
+
+class TestAsyncDeleteModel:
+    @pytest.mark.asyncio
+    async def test_delete_model(self, async_client):
+        expected_response_model = ModelDeleted.model_validate_json(mock_model_deleted_response_payload())
+        async_client._client.request.return_value = mock_response(200, expected_response_model.json())
+
+        response_model = await async_client.delete_model("model_id")
+
+        async_client._client.request.assert_called_once_with(
+            "delete",
+            "https://api.mistral.ai/v1/models/model_id",
+            headers={
+                "User-Agent": f"mistral-client-python/{async_client._version}",
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                "Authorization": "Bearer test_api_key",
+            },
+            json={},
+            data=None,
+        )
+
+        assert response_model == expected_response_model
+

--- a/tests/test_delete_model_async.py
+++ b/tests/test_delete_model_async.py
@@ -26,4 +26,3 @@ class TestAsyncDeleteModel:
         )
 
         assert response_model == expected_response_model
-

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -149,13 +149,13 @@ def mock_embedding_response_payload(batch_size: int = 1) -> str:
             "id": "embd-98c8c60e3fbf4fc49658eddaf447357c",
             "object": "list",
             "data": [
-                {
-                    "object": "embedding",
-                    "embedding": [-0.018585205078125, 0.027099609375, 0.02587890625],
-                    "index": 0,
-                }
-            ]
-            * batch_size,
+                        {
+                            "object": "embedding",
+                            "embedding": [-0.018585205078125, 0.027099609375, 0.02587890625],
+                            "index": 0,
+                        }
+                    ]
+                    * batch_size,
             "model": "mistral-embed",
             "usage": {"prompt_tokens": 90, "total_tokens": 90, "completion_tokens": 0},
         }
@@ -315,6 +315,16 @@ def mock_file_deleted_response_payload() -> str:
         {
             "id": "file_id",
             "object": "file",
+            "deleted": True,
+        }
+    )
+
+
+def mock_model_deleted_response_payload() -> str:
+    return orjson.dumps(
+        {
+            "id": "model_id",
+            "object": "model",
             "deleted": True,
         }
     )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -149,13 +149,13 @@ def mock_embedding_response_payload(batch_size: int = 1) -> str:
             "id": "embd-98c8c60e3fbf4fc49658eddaf447357c",
             "object": "list",
             "data": [
-                        {
-                            "object": "embedding",
-                            "embedding": [-0.018585205078125, 0.027099609375, 0.02587890625],
-                            "index": 0,
-                        }
-                    ]
-                    * batch_size,
+                {
+                    "object": "embedding",
+                    "embedding": [-0.018585205078125, 0.027099609375, 0.02587890625],
+                    "index": 0,
+                }
+            ]
+            * batch_size,
             "model": "mistral-embed",
             "usage": {"prompt_tokens": 90, "total_tokens": 90, "completion_tokens": 0},
         }


### PR DESCRIPTION
Adds support for the deletion of fine tuned model via the `delete_model` function, thanks  @arresejo for the initial [PR](https://github.com/mistralai/client-python/pull/104) 