### PR TITLE
Create version.py

### DIFF
--- a/src/mistralai/version.py
+++ b/src/mistralai/version.py
@@ -1,0 +1,7 @@
+from importlib import metadata
+
+try:
+    __version__ = metadata.version(__package__)
+except metadata.PackageNotFoundError:
+    # Case where package metadata is not available.
+    __version__ = ""


### PR DESCRIPTION
### **Changes:**
- exposed global variable `__version__` for mistralai package

### **To Test:**
- run `import mistralai`
- check that `mistralai.__version__` yields the package version

It's almost a standard nowadays to export the `__version__` variable in a python package. 

See https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package

Makes it easier for downstream dependencies to check against requirements on the `mistralai` package. 

