### PR TITLE
feat: add warning log when targeting a model planned for deprecation

### DIFF
--- a/src/mistralai/client_base.py
+++ b/src/mistralai/client_base.py
@@ -43,7 +43,7 @@ class ClientBase(ABC):
 
         self._version = CLIENT_VERSION
 
-    def _get_model(self, model: str | None = None) -> str:
+    def _get_model(self, model: Optional[str] = None) -> str:
         if model is not None:
             return model
         else:
@@ -86,7 +86,7 @@ class ClientBase(ABC):
 
         return parsed_messages
 
-    def _check_model_deprecation_header_callback_factory(self, model: str | None) -> Callable:
+    def _check_model_deprecation_header_callback_factory(self, model: Optional[str] = None) -> Callable:
         model = self._get_model(model)
 
         def _check_model_deprecation_header_callback(

--- a/src/mistralai/client_base.py
+++ b/src/mistralai/client_base.py
@@ -1,14 +1,19 @@
 import logging
 import os
 from abc import ABC
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import orjson
+from httpx import Headers
 
-from mistralai.exceptions import (
-    MistralException,
+from mistralai.constants import HEADER_MODEL_DEPRECATION_TIMESTAMP
+from mistralai.exceptions import MistralException
+from mistralai.models.chat_completion import (
+    ChatMessage,
+    Function,
+    ResponseFormat,
+    ToolChoice,
 )
-from mistralai.models.chat_completion import ChatMessage, Function, ResponseFormat, ToolChoice
 
 CLIENT_VERSION = "0.4.1"
 
@@ -37,6 +42,14 @@ class ClientBase(ABC):
             self._default_model = "mistral"
 
         self._version = CLIENT_VERSION
+
+    def _get_model(self, model: str | None = None) -> str:
+        if model is not None:
+            return model
+        else:
+            if self._default_model is None:
+                raise MistralException(message="model must be provided")
+            return self._default_model
 
     def _parse_tools(self, tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         parsed_tools: List[Dict[str, Any]] = []
@@ -73,6 +86,22 @@ class ClientBase(ABC):
 
         return parsed_messages
 
+    def _check_model_deprecation_header_callback_factory(self, model: str | None) -> Callable:
+        model = self._get_model(model)
+
+        def _check_model_deprecation_header_callback(
+            headers: Headers,
+        ) -> None:
+            if HEADER_MODEL_DEPRECATION_TIMESTAMP in headers:
+                self._logger.warning(
+                    f"WARNING: The model {model} is deprecated "
+                    f"and will be removed on {headers[HEADER_MODEL_DEPRECATION_TIMESTAMP]}. "
+                    "Please refer to https://docs.mistral.ai/getting-started/models/#api-versioning "
+                    "for more information."
+                )
+
+        return _check_model_deprecation_header_callback
+
     def _make_completion_request(
         self,
         prompt: str,
@@ -95,16 +124,14 @@ class ClientBase(ABC):
         if stop is not None:
             request_data["stop"] = stop
 
-        if model is not None:
-            request_data["model"] = model
-        else:
-            if self._default_model is None:
-                raise MistralException(message="model must be provided")
-            request_data["model"] = self._default_model
+        request_data["model"] = self._get_model(model)
 
         request_data.update(
             self._build_sampling_params(
-                temperature=temperature, max_tokens=max_tokens, top_p=top_p, random_seed=random_seed
+                temperature=temperature,
+                max_tokens=max_tokens,
+                top_p=top_p,
+                random_seed=random_seed,
             )
         )
 
@@ -148,16 +175,14 @@ class ClientBase(ABC):
             "messages": self._parse_messages(messages),
         }
 
-        if model is not None:
-            request_data["model"] = model
-        else:
-            if self._default_model is None:
-                raise MistralException(message="model must be provided")
-            request_data["model"] = self._default_model
+        request_data["model"] = self._get_model(model)
 
         request_data.update(
             self._build_sampling_params(
-                temperature=temperature, max_tokens=max_tokens, top_p=top_p, random_seed=random_seed
+                temperature=temperature,
+                max_tokens=max_tokens,
+                top_p=top_p,
+                random_seed=random_seed,
             )
         )
 

--- a/src/mistralai/constants.py
+++ b/src/mistralai/constants.py
@@ -1,3 +1,5 @@
 RETRY_STATUS_CODES = {429, 500, 502, 503, 504}
 
 ENDPOINT = "https://api.mistral.ai"
+
+HEADER_MODEL_DEPRECATION_TIMESTAMP = "x-model-deprecation-timestamp"

--- a/tests/test_chat_async.py
+++ b/tests/test_chat_async.py
@@ -1,6 +1,11 @@
+import io
+import logging
 import unittest.mock as mock
 
 import pytest
+from mistralai.constants import (
+    HEADER_MODEL_DEPRECATION_TIMESTAMP,
+)
 from mistralai.models.chat_completion import (
     ChatCompletionResponse,
     ChatCompletionStreamResponse,
@@ -17,11 +22,25 @@ from .utils import (
 
 class TestAsyncChat:
     @pytest.mark.asyncio
-    async def test_chat(self, async_client):
-        async_client._client.request.return_value = mock_response(
-            200,
-            mock_chat_response_payload(),
+    @pytest.mark.parametrize("target_deprecated_model", [True, False], ids=["deprecated", "not_deprecated"])
+    async def test_chat(self, async_client, target_deprecated_model):
+        headers = (
+            {
+                HEADER_MODEL_DEPRECATION_TIMESTAMP: "2023-12-01T00:00:00",
+            }
+            if target_deprecated_model
+            else {}
         )
+
+        async_client._client.request.return_value = mock_response(200, mock_chat_response_payload(), headers)
+
+        # Create a stream to capture the log output
+        log_stream = io.StringIO()
+
+        # Create a logger and add a handler that writes to the stream
+        logger = async_client._logger
+        handler = logging.StreamHandler(log_stream)
+        logger.addHandler(handler)
 
         result = await async_client.chat(
             model="mistral-small-latest",
@@ -50,13 +69,42 @@ class TestAsyncChat:
         assert result.choices[0].index == 0
         assert result.object == "chat.completion"
 
+        # Check if the log message was produced when the model is deprecated
+        log_output = log_stream.getvalue()
+        excepted_log = (
+            (
+                "WARNING: The model mistral-small-latest is deprecated "
+                "and will be removed on 2023-12-01T00:00:00. "
+                "Please refer to https://docs.mistral.ai/getting-started/models/#api-versioning for more information.\n"
+            )
+            if target_deprecated_model
+            else ""
+        )
+        assert excepted_log == log_output
+
     @pytest.mark.asyncio
-    async def test_chat_streaming(self, async_client):
+    @pytest.mark.parametrize("target_deprecated_model", [True, False], ids=["deprecated", "not_deprecated"])
+    async def test_chat_streaming(self, async_client, target_deprecated_model):
+        headers = (
+            {
+                HEADER_MODEL_DEPRECATION_TIMESTAMP: "2023-12-01T00:00:00",
+            }
+            if target_deprecated_model
+            else {}
+        )
+
         async_client._client.stream = mock.Mock()
         async_client._client.stream.return_value = mock_async_stream_response(
-            200,
-            mock_chat_response_streaming_payload(),
+            200, mock_chat_response_streaming_payload(), headers
         )
+
+        # Create a stream to capture the log output
+        log_stream = io.StringIO()
+
+        # Create a logger and add a handler that writes to the stream
+        logger = async_client._logger
+        handler = logging.StreamHandler(log_stream)
+        logger.addHandler(handler)
 
         result = async_client.chat_stream(
             model="mistral-small-latest",
@@ -94,3 +142,16 @@ class TestAsyncChat:
                 assert result.choices[0].index == i - 1
                 assert result.choices[0].delta.content == f"stream response {i-1}"
                 assert result.object == "chat.completion.chunk"
+
+        # Check if the log message was produced when the model is deprecated
+        log_output = log_stream.getvalue()
+        excepted_log = (
+            (
+                "WARNING: The model mistral-small-latest is deprecated "
+                "and will be removed on 2023-12-01T00:00:00. "
+                "Please refer to https://docs.mistral.ai/getting-started/models/#api-versioning for more information.\n"
+            )
+            if target_deprecated_model
+            else ""
+        )
+        assert excepted_log == log_output

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,23 +1,25 @@
 import contextlib
 import unittest.mock as mock
-from typing import List
+from typing import Any, Dict, List
 
 import orjson
 from httpx import Response
 
 
 @contextlib.contextmanager
-def mock_stream_response(status_code: int, content: List[str]):
+def mock_stream_response(status_code: int, content: List[str], headers: Dict[str, Any] = None):
     response = mock.Mock(Response)
     response.status_code = status_code
+    response.headers = headers if headers else {}
     response.iter_lines.return_value = iter(content)
     yield response
 
 
 @contextlib.asynccontextmanager
-async def mock_async_stream_response(status_code: int, content: List[str]):
+async def mock_async_stream_response(status_code: int, content: List[str], headers: Dict[str, Any] = None):
     response = mock.Mock(Response)
     response.status_code = status_code
+    response.headers = headers if headers else {}
 
     async def async_iter(content: List[str]):
         for line in content:
@@ -27,9 +29,12 @@ async def mock_async_stream_response(status_code: int, content: List[str]):
     yield response
 
 
-def mock_response(status_code: int, content: str, is_json: bool = True) -> mock.MagicMock:
+def mock_response(
+    status_code: int, content: str, headers: Dict[str, Any] = None, is_json: bool = True
+) -> mock.MagicMock:
     response = mock.Mock(Response)
     response.status_code = status_code
+    response.headers = headers if headers else {}
     if is_json:
         response.json = mock.MagicMock()
         response.json.return_value = orjson.loads(content)


### PR DESCRIPTION
This PR implements the following: now the client will leverage the `x-model-deprecation-timestamp` header (only appear if a model deprecation is planned) to log a warning about the deprecation, the warning log includes the model name and timestamp of deprecation.