### PR TITLE
Fix link to the Discord server

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://docs.mistral.ai
     about: Developer documentation for the Mistral AI platform
   - name: Discord
-    url: https://discord.com/invite/mistralai)
+    url: https://discord.com/invite/mistralai
     about: Chat with the Mistral community


### PR DESCRIPTION
Noticed on the issue template page:

![image](https://github.com/user-attachments/assets/a1dc8f54-0223-4754-8cee-402147d6b959)

The link seems to have an extra parenthesis.