### PR TITLE
add `prefix` attribute to `ChatMessage` class

### DIFF
--- a/src/mistralai/models/chat_completion.py
+++ b/src/mistralai/models/chat_completion.py
@@ -48,6 +48,7 @@ class ChatMessage(BaseModel):
     name: Optional[str] = None
     tool_calls: Optional[List[ToolCall]] = None
     tool_call_id: Optional[str] = None
+    prefix: Optional[bool] = None
 
 
 class DeltaMessage(BaseModel):


### PR DESCRIPTION
This allows the setting of a 'prefix' message when using the `ChatMessage` object.