### PR TITLE
Added the stop parameter to chat completion functions.

### DIFF
--- a/src/mistralai/async_client.py
+++ b/src/mistralai/async_client.py
@@ -185,6 +185,7 @@ class MistralAsyncClient(ClientBase):
         safe_prompt: bool = False,
         tool_choice: Optional[Union[str, ToolChoice]] = None,
         response_format: Optional[Union[Dict[str, str], ResponseFormat]] = None,
+        stop: Optional[List[str]] = None
     ) -> ChatCompletionResponse:
         """A asynchronous chat endpoint that returns a single response.
 
@@ -199,6 +200,7 @@ class MistralAsyncClient(ClientBase):
             random_seed (Optional[int], optional): the random seed to use for sampling, e.g. 42. Defaults to None.
             safe_mode (bool, optional): deprecated, use safe_prompt instead. Defaults to False.
             safe_prompt (bool, optional): whether to use safe prompt, e.g. true. Defaults to False.
+            stop (Optional[str], optional): list of stop tokens; generation halts when encountering a stop token. Defaults to None.
 
         Returns:
             ChatCompletionResponse: a response object containing the generated text.
@@ -215,6 +217,7 @@ class MistralAsyncClient(ClientBase):
             safe_prompt=safe_mode or safe_prompt,
             tool_choice=tool_choice,
             response_format=response_format,
+            stop=stop
         )
 
         single_response = self._request(
@@ -242,6 +245,7 @@ class MistralAsyncClient(ClientBase):
         safe_prompt: bool = False,
         tool_choice: Optional[Union[str, ToolChoice]] = None,
         response_format: Optional[Union[Dict[str, str], ResponseFormat]] = None,
+        stop: Optional[List[str]] = None
     ) -> AsyncGenerator[ChatCompletionStreamResponse, None]:
         """An Asynchronous chat endpoint that streams responses.
 
@@ -257,6 +261,7 @@ class MistralAsyncClient(ClientBase):
             random_seed (Optional[int], optional): the random seed to use for sampling, e.g. 42. Defaults to None.
             safe_mode (bool, optional): deprecated, use safe_prompt instead. Defaults to False.
             safe_prompt (bool, optional): whether to use safe prompt, e.g. true. Defaults to False.
+            stop (Optional[str], optional): list of stop tokens; generation halts when encountering a stop token. Defaults to None.
 
         Returns:
             AsyncGenerator[ChatCompletionStreamResponse, None]:
@@ -275,6 +280,7 @@ class MistralAsyncClient(ClientBase):
             safe_prompt=safe_mode or safe_prompt,
             tool_choice=tool_choice,
             response_format=response_format,
+            stop=stop
         )
         async_response = self._request(
             "post",

--- a/src/mistralai/client.py
+++ b/src/mistralai/client.py
@@ -180,6 +180,7 @@ class MistralClient(ClientBase):
         safe_prompt: bool = False,
         tool_choice: Optional[Union[str, ToolChoice]] = None,
         response_format: Optional[Union[Dict[str, str], ResponseFormat]] = None,
+        stop: Optional[List[str]] = None
     ) -> ChatCompletionResponse:
         """A chat endpoint that returns a single response.
 
@@ -195,6 +196,7 @@ class MistralClient(ClientBase):
             random_seed (Optional[int], optional): the random seed to use for sampling, e.g. 42. Defaults to None.
             safe_mode (bool, optional): deprecated, use safe_prompt instead. Defaults to False.
             safe_prompt (bool, optional): whether to use safe prompt, e.g. true. Defaults to False.
+            stop (Optional[str], optional): list of stop tokens; generation halts when encountering a stop token. Defaults to None.
 
         Returns:
             ChatCompletionResponse: a response object containing the generated text.
@@ -211,6 +213,7 @@ class MistralClient(ClientBase):
             safe_prompt=safe_mode or safe_prompt,
             tool_choice=tool_choice,
             response_format=response_format,
+            stop=stop
         )
 
         single_response = self._request(
@@ -362,7 +365,7 @@ class MistralClient(ClientBase):
         single_response = self._request(
             "post",
             request,
-            "v1/fim/completions",
+            "v1/chat/completions",
             stream=False,
             check_model_deprecation_headers_callback=self._check_model_deprecation_header_callback_factory(model),
         )

--- a/src/mistralai/client_base.py
+++ b/src/mistralai/client_base.py
@@ -170,6 +170,7 @@ class ClientBase(ABC):
         safe_prompt: Optional[bool] = False,
         tool_choice: Optional[Union[str, ToolChoice]] = None,
         response_format: Optional[Union[Dict[str, str], ResponseFormat]] = None,
+        stop: Optional[List[str]] = None
     ) -> Dict[str, Any]:
         request_data: Dict[str, Any] = {
             "messages": self._parse_messages(messages),
@@ -197,6 +198,9 @@ class ClientBase(ABC):
             request_data["tool_choice"] = self._parse_tool_choice(tool_choice)
         if response_format is not None:
             request_data["response_format"] = self._parse_response_format(response_format)
+
+        if stop is not None:
+            request_data["stop"] = stop
 
         self._logger.debug(f"Chat request: {request_data}")
 


### PR DESCRIPTION
The Mistral API supports stop tokens on the chat completion endpoint, but the library does not. This fixes issue #41 and adds the stop parameter.