### PR TITLE
Added support for prefix and stop tokens

### DIFF
--- a/src/mistralai/async_client.py
+++ b/src/mistralai/async_client.py
@@ -185,6 +185,7 @@ class MistralAsyncClient(ClientBase):
         safe_prompt: bool = False,
         tool_choice: Optional[Union[str, ToolChoice]] = None,
         response_format: Optional[Union[Dict[str, str], ResponseFormat]] = None,
+        stop: Optional[List[str]] = None
     ) -> ChatCompletionResponse:
         """A asynchronous chat endpoint that returns a single response.
 
@@ -199,6 +200,7 @@ class MistralAsyncClient(ClientBase):
             random_seed (Optional[int], optional): the random seed to use for sampling, e.g. 42. Defaults to None.
             safe_mode (bool, optional): deprecated, use safe_prompt instead. Defaults to False.
             safe_prompt (bool, optional): whether to use safe prompt, e.g. true. Defaults to False.
+            stop (Optional[str], optional): list of stop tokens; generation halts when encountering a stop token. Defaults to None.
 
         Returns:
             ChatCompletionResponse: a response object containing the generated text.
@@ -215,6 +217,7 @@ class MistralAsyncClient(ClientBase):
             safe_prompt=safe_mode or safe_prompt,
             tool_choice=tool_choice,
             response_format=response_format,
+            stop=stop
         )
 
         single_response = self._request(
@@ -242,6 +245,7 @@ class MistralAsyncClient(ClientBase):
         safe_prompt: bool = False,
         tool_choice: Optional[Union[str, ToolChoice]] = None,
         response_format: Optional[Union[Dict[str, str], ResponseFormat]] = None,
+        stop: Optional[List[str]] = None
     ) -> AsyncGenerator[ChatCompletionStreamResponse, None]:
         """An Asynchronous chat endpoint that streams responses.
 
@@ -257,6 +261,7 @@ class MistralAsyncClient(ClientBase):
             random_seed (Optional[int], optional): the random seed to use for sampling, e.g. 42. Defaults to None.
             safe_mode (bool, optional): deprecated, use safe_prompt instead. Defaults to False.
             safe_prompt (bool, optional): whether to use safe prompt, e.g. true. Defaults to False.
+            stop (Optional[str], optional): list of stop tokens; generation halts when encountering a stop token. Defaults to None.
 
         Returns:
             AsyncGenerator[ChatCompletionStreamResponse, None]:
@@ -275,6 +280,7 @@ class MistralAsyncClient(ClientBase):
             safe_prompt=safe_mode or safe_prompt,
             tool_choice=tool_choice,
             response_format=response_format,
+            stop=stop
         )
         async_response = self._request(
             "post",

--- a/src/mistralai/async_client.py
+++ b/src/mistralai/async_client.py
@@ -185,7 +185,7 @@ class MistralAsyncClient(ClientBase):
         safe_prompt: bool = False,
         tool_choice: Optional[Union[str, ToolChoice]] = None,
         response_format: Optional[Union[Dict[str, str], ResponseFormat]] = None,
-        stop: Optional[List[str]] = None
+        stop: Optional[List[str]] = None,
     ) -> ChatCompletionResponse:
         """A asynchronous chat endpoint that returns a single response.
 
@@ -200,7 +200,8 @@ class MistralAsyncClient(ClientBase):
             random_seed (Optional[int], optional): the random seed to use for sampling, e.g. 42. Defaults to None.
             safe_mode (bool, optional): deprecated, use safe_prompt instead. Defaults to False.
             safe_prompt (bool, optional): whether to use safe prompt, e.g. true. Defaults to False.
-            stop (Optional[str], optional): list of stop tokens; generation halts when encountering a stop token. Defaults to None.
+            stop (Optional[str], optional): list of stop tokens; generation halts when encountering a stop token.
+            Defaults to None.
 
         Returns:
             ChatCompletionResponse: a response object containing the generated text.
@@ -217,7 +218,7 @@ class MistralAsyncClient(ClientBase):
             safe_prompt=safe_mode or safe_prompt,
             tool_choice=tool_choice,
             response_format=response_format,
-            stop=stop
+            stop=stop,
         )
 
         single_response = self._request(
@@ -245,7 +246,7 @@ class MistralAsyncClient(ClientBase):
         safe_prompt: bool = False,
         tool_choice: Optional[Union[str, ToolChoice]] = None,
         response_format: Optional[Union[Dict[str, str], ResponseFormat]] = None,
-        stop: Optional[List[str]] = None
+        stop: Optional[List[str]] = None,
     ) -> AsyncGenerator[ChatCompletionStreamResponse, None]:
         """An Asynchronous chat endpoint that streams responses.
 
@@ -261,7 +262,8 @@ class MistralAsyncClient(ClientBase):
             random_seed (Optional[int], optional): the random seed to use for sampling, e.g. 42. Defaults to None.
             safe_mode (bool, optional): deprecated, use safe_prompt instead. Defaults to False.
             safe_prompt (bool, optional): whether to use safe prompt, e.g. true. Defaults to False.
-            stop (Optional[str], optional): list of stop tokens; generation halts when encountering a stop token. Defaults to None.
+            stop (Optional[str], optional): list of stop tokens; generation halts when encountering a stop token.
+            Defaults to None.
 
         Returns:
             AsyncGenerator[ChatCompletionStreamResponse, None]:
@@ -280,7 +282,7 @@ class MistralAsyncClient(ClientBase):
             safe_prompt=safe_mode or safe_prompt,
             tool_choice=tool_choice,
             response_format=response_format,
-            stop=stop
+            stop=stop,
         )
         async_response = self._request(
             "post",

--- a/src/mistralai/client.py
+++ b/src/mistralai/client.py
@@ -275,6 +275,8 @@ class MistralClient(ClientBase):
             response_format=response_format,
         )
 
+        breakpoint()
+
         response = self._request(
             "post",
             request,

--- a/src/mistralai/client.py
+++ b/src/mistralai/client.py
@@ -180,6 +180,7 @@ class MistralClient(ClientBase):
         safe_prompt: bool = False,
         tool_choice: Optional[Union[str, ToolChoice]] = None,
         response_format: Optional[Union[Dict[str, str], ResponseFormat]] = None,
+        stop: Optional[List[str]] = None
     ) -> ChatCompletionResponse:
         """A chat endpoint that returns a single response.
 
@@ -195,6 +196,7 @@ class MistralClient(ClientBase):
             random_seed (Optional[int], optional): the random seed to use for sampling, e.g. 42. Defaults to None.
             safe_mode (bool, optional): deprecated, use safe_prompt instead. Defaults to False.
             safe_prompt (bool, optional): whether to use safe prompt, e.g. true. Defaults to False.
+            stop (Optional[str], optional): list of stop tokens; generation halts when encountering a stop token. Defaults to None.
 
         Returns:
             ChatCompletionResponse: a response object containing the generated text.
@@ -211,6 +213,7 @@ class MistralClient(ClientBase):
             safe_prompt=safe_mode or safe_prompt,
             tool_choice=tool_choice,
             response_format=response_format,
+            stop=stop
         )
 
         single_response = self._request(
@@ -362,7 +365,7 @@ class MistralClient(ClientBase):
         single_response = self._request(
             "post",
             request,
-            "v1/fim/completions",
+            "v1/chat/completions",
             stream=False,
             check_model_deprecation_headers_callback=self._check_model_deprecation_header_callback_factory(model),
         )

--- a/src/mistralai/client.py
+++ b/src/mistralai/client.py
@@ -366,7 +366,7 @@ class MistralClient(ClientBase):
         single_response = self._request(
             "post",
             request,
-            "v1/chat/completions",
+            "v1/fim/completions",
             stream=False,
             check_model_deprecation_headers_callback=self._check_model_deprecation_header_callback_factory(model),
         )

--- a/src/mistralai/client.py
+++ b/src/mistralai/client.py
@@ -216,6 +216,9 @@ class MistralClient(ClientBase):
             stop=stop
         )
 
+        print(request)
+        breakpoint()
+
         single_response = self._request(
             "post",
             request,
@@ -275,6 +278,7 @@ class MistralClient(ClientBase):
             response_format=response_format,
         )
 
+        print(request)
         breakpoint()
 
         response = self._request(
@@ -363,6 +367,9 @@ class MistralClient(ClientBase):
         request = self._make_completion_request(
             prompt, model, suffix, temperature, max_tokens, top_p, random_seed, stop
         )
+
+        print(request)
+        breakpoint()
 
         single_response = self._request(
             "post",

--- a/src/mistralai/client.py
+++ b/src/mistralai/client.py
@@ -180,7 +180,7 @@ class MistralClient(ClientBase):
         safe_prompt: bool = False,
         tool_choice: Optional[Union[str, ToolChoice]] = None,
         response_format: Optional[Union[Dict[str, str], ResponseFormat]] = None,
-        stop: Optional[List[str]] = None
+        stop: Optional[List[str]] = None,
     ) -> ChatCompletionResponse:
         """A chat endpoint that returns a single response.
 
@@ -196,7 +196,8 @@ class MistralClient(ClientBase):
             random_seed (Optional[int], optional): the random seed to use for sampling, e.g. 42. Defaults to None.
             safe_mode (bool, optional): deprecated, use safe_prompt instead. Defaults to False.
             safe_prompt (bool, optional): whether to use safe prompt, e.g. true. Defaults to False.
-            stop (Optional[str], optional): list of stop tokens; generation halts when encountering a stop token. Defaults to None.
+            stop (Optional[str], optional): list of stop tokens; generation halts when encountering a stop token.
+            Defaults to None.
 
         Returns:
             ChatCompletionResponse: a response object containing the generated text.
@@ -213,11 +214,8 @@ class MistralClient(ClientBase):
             safe_prompt=safe_mode or safe_prompt,
             tool_choice=tool_choice,
             response_format=response_format,
-            stop=stop
+            stop=stop,
         )
-
-        print(request)
-        breakpoint()
 
         single_response = self._request(
             "post",
@@ -277,9 +275,6 @@ class MistralClient(ClientBase):
             tool_choice=tool_choice,
             response_format=response_format,
         )
-
-        print(request)
-        breakpoint()
 
         response = self._request(
             "post",
@@ -367,9 +362,6 @@ class MistralClient(ClientBase):
         request = self._make_completion_request(
             prompt, model, suffix, temperature, max_tokens, top_p, random_seed, stop
         )
-
-        print(request)
-        breakpoint()
 
         single_response = self._request(
             "post",

--- a/src/mistralai/client_base.py
+++ b/src/mistralai/client_base.py
@@ -170,6 +170,7 @@ class ClientBase(ABC):
         safe_prompt: Optional[bool] = False,
         tool_choice: Optional[Union[str, ToolChoice]] = None,
         response_format: Optional[Union[Dict[str, str], ResponseFormat]] = None,
+        stop: Optional[List[str]] = None
     ) -> Dict[str, Any]:
         request_data: Dict[str, Any] = {
             "messages": self._parse_messages(messages),
@@ -197,6 +198,9 @@ class ClientBase(ABC):
             request_data["tool_choice"] = self._parse_tool_choice(tool_choice)
         if response_format is not None:
             request_data["response_format"] = self._parse_response_format(response_format)
+
+        if stop is not None:
+            request_data["stop"] = stop
 
         self._logger.debug(f"Chat request: {request_data}")
 

--- a/src/mistralai/client_base.py
+++ b/src/mistralai/client_base.py
@@ -170,7 +170,7 @@ class ClientBase(ABC):
         safe_prompt: Optional[bool] = False,
         tool_choice: Optional[Union[str, ToolChoice]] = None,
         response_format: Optional[Union[Dict[str, str], ResponseFormat]] = None,
-        stop: Optional[List[str]] = None
+        stop: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         request_data: Dict[str, Any] = {
             "messages": self._parse_messages(messages),

--- a/src/mistralai/models/chat_completion.py
+++ b/src/mistralai/models/chat_completion.py
@@ -48,7 +48,7 @@ class ChatMessage(BaseModel):
     name: Optional[str] = None
     tool_calls: Optional[List[ToolCall]] = None
     tool_call_id: Optional[str] = None
-    prefix: Optional[str] = None
+    prefix: Optional[bool] = None
 
 
 class DeltaMessage(BaseModel):

--- a/src/mistralai/models/chat_completion.py
+++ b/src/mistralai/models/chat_completion.py
@@ -48,6 +48,7 @@ class ChatMessage(BaseModel):
     name: Optional[str] = None
     tool_calls: Optional[List[ToolCall]] = None
     tool_call_id: Optional[str] = None
+    prefix: Optional[str] = None
 
 
 class DeltaMessage(BaseModel):

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -14,6 +14,7 @@ from .utils import (
     mock_chat_response_streaming_payload,
     mock_response,
     mock_stream_response,
+    mock_chat_response_payload_with_stop_token,
 )
 
 
@@ -136,6 +137,77 @@ class TestChat:
                 assert result.object == "chat.completion.chunk"
 
         # Check if the log message was produced
+        log_output = log_stream.getvalue()
+        excepted_log = (
+            (
+                "WARNING: The model mistral-small-latest is deprecated "
+                "and will be removed on 2023-12-01T00:00:00. "
+                "Please refer to https://docs.mistral.ai/getting-started/models/#api-versioning for more information.\n"
+            )
+            if target_deprecated_model
+            else ""
+        )
+        assert excepted_log == log_output
+
+
+    @pytest.mark.parametrize("target_deprecated_model", [True, False], ids=["deprecated", "not_deprecated"])
+    def test_chat_stop(self, client, target_deprecated_model):
+        headers = (
+            {
+                HEADER_MODEL_DEPRECATION_TIMESTAMP: "2023-12-01T00:00:00",
+            }
+            if target_deprecated_model
+            else {}
+        )
+
+        client._client.request.return_value = mock_response(200, mock_chat_response_payload_with_stop_token(), headers)
+
+        # Create a stream to capture the log output
+        log_stream = io.StringIO()
+
+        # Create a logger and add a handler that writes to the stream
+        logger = client._logger
+        handler = logging.StreamHandler(log_stream)
+        logger.addHandler(handler)
+
+        chat_messages = dict(model="mistral-small-latest",
+                    messages=[ChatMessage(role="user", content="What is the the capital of France?"),
+                              ChatMessage(role="assistant", content="The", prefix=True)],
+            stop=["France"])
+        result = client.chat(
+            **chat_messages
+        )
+
+        client._client.request.assert_called_once_with(
+            "post",
+            "https://api.mistral.ai/v1/chat/completions",
+            headers={
+                "User-Agent": f"mistral-client-python/{client._version}",
+                "Accept": "application/json",
+                "Authorization": "Bearer test_api_key",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": "mistral-small-latest",
+                "messages": [{"role": "user", "content": "What is the the capital of France?"},
+                             {"role": "assistant", "content":"The", "prefix":True}],
+                "stream": False,
+                'stop': ['France'],
+            },
+            data=None,
+        )
+
+        print("***")
+        print(chat_messages)
+        print(result)
+        
+        assert isinstance(result, ChatCompletionResponse), "Should return an ChatCompletionResponse"
+        assert len(result.choices) == 1
+        assert result.choices[0].index == 0
+        assert result.object == "chat.completion"
+        assert result.choices[0].message.content == "The capital of "
+
+        # Check if the log message was produced when the model is deprecated
         log_output = log_stream.getvalue()
         excepted_log = (
             (

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -197,10 +197,6 @@ class TestChat:
             data=None,
         )
 
-        print("***")
-        print(chat_messages)
-        print(result)
-        
         assert isinstance(result, ChatCompletionResponse), "Should return an ChatCompletionResponse"
         assert len(result.choices) == 1
         assert result.choices[0].index == 0

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -188,6 +188,31 @@ def mock_chat_response_payload():
         }
     ).decode()
 
+def mock_chat_response_payload_with_stop_token():
+    return orjson.dumps(
+        {
+            "id": '5927f2f09c9e46f5bc0837c63dfc871c',
+            "object": 'chat.completion',
+            "created": 1722532978,
+            "model": 'mistral-small-latest',
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": 'assistant', 
+                        "content": 'The capital of ', 
+                        "name": None, 
+                        "tool_calls": None, 
+                        "tool_call_id": None, 
+                        "prefix": None
+                    }, 
+                    "finish_reason": 'stop',
+                }
+            ],
+            "usage": {"prompt_tokens": 12, "total_tokens": 16, "completion_tokens": 4},
+            }
+        ).decode()
+
 
 def mock_chat_response_streaming_payload():
     return [


### PR DESCRIPTION
The API supports both `stop` and `prefix` as arguments in a chat message:
https://docs.mistral.ai/capabilities/completion/#other-useful-features

This change adds support for those, as well as a test that demonstrates them in action.