### PR TITLE
feat: add default_headers to MistralAI client

### DIFF
--- a/src/mistralai/client.py
+++ b/src/mistralai/client.py
@@ -34,12 +34,14 @@ class MistralClient(ClientBase):
         self,
         api_key: Optional[str] = None,
         endpoint: str = ENDPOINT,
+        default_headers: Optional[Dict[str, str]] = None,
         max_retries: int = 5,
         timeout: int = 120,
     ):
         super().__init__(endpoint, api_key, max_retries, timeout)
 
         self._client = Client(
+            headers=default_headers,
             follow_redirects=True,
             timeout=self._timeout,
             transport=HTTPTransport(retries=self._max_retries),


### PR DESCRIPTION
- Other LLM clients like OpenAI already support this
- This is useful for LLM Telemetry

Ref: https://github.com/mistralai/client-python/issues/85