### PR TITLE
bug fix: Add enum eos_token to FinishReason class

### DIFF
--- a/src/mistralai/models/chat_completion.py
+++ b/src/mistralai/models/chat_completion.py
@@ -61,6 +61,7 @@ class FinishReason(str, Enum):
     length = "length"
     error = "error"
     tool_calls = "tool_calls"
+    eos_token = "eos_token"
 
 
 class ChatCompletionResponseStreamChoice(BaseModel):


### PR DESCRIPTION
Issue caused when we use TGI server and the finish reason being eos_token causing the pydantic error.

```
    self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 1 validation error for ChatCompletionResponse
choices.0.finish_reason
  Input should be 'stop', 'length', 'error' or 'tool_calls' [type=enum, input_value='eos_token', input_type=str]

```

This PR should fixed the issue