### PR TITLE
Updating Migration file by using the new changes

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -107,10 +107,7 @@ model = "mistral-large-latest"
 client = Mistral(api_key=api_key)
 
  messages = [
-    {
-        "role": "user",
-        "content": "What is the best French cheese?",
-    },
+    UserMessage(role="user", content="What is the best French cheese?")
  ]
 
 chat_response = client.chat.complete(
@@ -154,10 +151,7 @@ model = "mistral-large-latest"
 client = Mistral(api_key=api_key)
 
 messages = [
-    {
-        "role": "user",
-        "content": "What is the best French cheese?",
-    },
+    UserMessage(role="user", content="What is the best French cheese?")
 ]
 
 stream_response = client.chat.stream(
@@ -202,10 +196,7 @@ model = "mistral-large-latest"
 client = Mistral(api_key=api_key)
 
 messages = [
-    {
-        "role": "user",
-        "content": "What is the best French cheese?",
-    },
+    UserMessage(role="user", content="What is the best French cheese?")
 ]
 
 # With async


### PR DESCRIPTION
The `ChatMessage` class has been replaced with a more flexible system. You can now use the `SystemMessage`, `UserMessage`, `AssistantMessage`, and `ToolMessage` classes to create messages. In the migration file, the UserMessage file was imported but not being used to show the users on how to use this new revamped class, how it differs from the previously used ChatMessage and in it's use cases in the below examples. This will help the users transition after the new updates to mistralai python client.