### PR TITLE
Fix streaming response with empty content

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,12 +1,12 @@
 lockVersion: 2.0.0
 id: 2d045ec7-2ebb-4f4d-ad25-40953b132161
 management:
-  docChecksum: c19f5a86b8045af32a46604ee5478061
+  docChecksum: 87135817a5a746d7466c41070e5f581e
   docVersion: 0.0.2
-  speakeasyVersion: 1.372.0
+  speakeasyVersion: 1.373.1
   generationVersion: 2.399.0
-  releaseVersion: 1.1.3
-  configChecksum: b9757e45cfabeceebf51f9a514724903
+  releaseVersion: 1.0.1
+  configChecksum: 374a669373f10730cda1eb9a91d59b8b
   repoURL: https://github.com/mistralai/client-python.git
   installationURL: https://github.com/mistralai/client-python.git
   published: true

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -12,7 +12,7 @@ generation:
   auth:
     oAuth2ClientCredentialsEnabled: true
 python:
-  version: 1.1.3
+  version: 1.0.1
   additionalDependencies:
     dev:
       pytest: ^8.2.2

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,41 +1,41 @@
-speakeasyVersion: 1.372.0
+speakeasyVersion: 1.373.1
 sources:
     mistral-azure-source:
         sourceNamespace: mistral-openapi-azure
-        sourceRevisionDigest: sha256:bc53dba5935490a409045de3c39ccf9e90243a289656dd538a542990aa376cca
-        sourceBlobDigest: sha256:4173c3be19775dd2bdd4ce28bb9ae6655650df75f2b689a44c3362d418d69d49
+        sourceRevisionDigest: sha256:becb324b11dfc5155aa0cc420ca312d0af5aecfcbad22fe90066a09561ae4e6a
+        sourceBlobDigest: sha256:84928a6297c3a838dce719ffa3da1e221cba968ce4a6c74d5c3bb41bf86a7e5d
         tags:
             - latest
     mistral-google-cloud-source:
         sourceNamespace: mistral-openapi-google-cloud
-        sourceRevisionDigest: sha256:ab52d75474e071db240ed9a5367dc6374867b5c9306d478dcfdf8f7b7d08607f
-        sourceBlobDigest: sha256:d5f9c665861d7fedd5093567d13e1f7f6a12b82137fbbecda4708007b15030ba
+        sourceRevisionDigest: sha256:7fee22ae1a434b8919112c7feae87af7f1378952fcc6bde081deb55f65e5bfc2
+        sourceBlobDigest: sha256:a4c011f461c73809a7d6cf1c9823d3c51d5050895aad246287ff14ac971efb8c
         tags:
             - latest
     mistral-openapi:
         sourceNamespace: mistral-openapi
-        sourceRevisionDigest: sha256:e4d5f5fe40e7f1141006ba40c1d85b743ce5dc2407635ca2e776ba0dfb00a398
-        sourceBlobDigest: sha256:56f1bbe3a050c9505e003bb9790e443084922bff74b072805757076cdb8a136e
+        sourceRevisionDigest: sha256:088d899162941380ec90445852dc7e8c65a8e2eab6b32f552fd7f4fc6f152e76
+        sourceBlobDigest: sha256:feb2a952c0f5757a656e8fed5614e28bc4da195cbeb548b5aaf4fc09aee4ddac
         tags:
             - latest
 targets:
     mistralai-azure-sdk:
         source: mistral-azure-source
         sourceNamespace: mistral-openapi-azure
-        sourceRevisionDigest: sha256:bc53dba5935490a409045de3c39ccf9e90243a289656dd538a542990aa376cca
-        sourceBlobDigest: sha256:4173c3be19775dd2bdd4ce28bb9ae6655650df75f2b689a44c3362d418d69d49
+        sourceRevisionDigest: sha256:becb324b11dfc5155aa0cc420ca312d0af5aecfcbad22fe90066a09561ae4e6a
+        sourceBlobDigest: sha256:84928a6297c3a838dce719ffa3da1e221cba968ce4a6c74d5c3bb41bf86a7e5d
         outLocation: ./packages/mistralai_azure
     mistralai-gcp-sdk:
         source: mistral-google-cloud-source
         sourceNamespace: mistral-openapi-google-cloud
-        sourceRevisionDigest: sha256:ab52d75474e071db240ed9a5367dc6374867b5c9306d478dcfdf8f7b7d08607f
-        sourceBlobDigest: sha256:d5f9c665861d7fedd5093567d13e1f7f6a12b82137fbbecda4708007b15030ba
+        sourceRevisionDigest: sha256:7fee22ae1a434b8919112c7feae87af7f1378952fcc6bde081deb55f65e5bfc2
+        sourceBlobDigest: sha256:a4c011f461c73809a7d6cf1c9823d3c51d5050895aad246287ff14ac971efb8c
         outLocation: ./packages/mistralai_gcp
     mistralai-sdk:
         source: mistral-openapi
         sourceNamespace: mistral-openapi
-        sourceRevisionDigest: sha256:e4d5f5fe40e7f1141006ba40c1d85b743ce5dc2407635ca2e776ba0dfb00a398
-        sourceBlobDigest: sha256:56f1bbe3a050c9505e003bb9790e443084922bff74b072805757076cdb8a136e
+        sourceRevisionDigest: sha256:088d899162941380ec90445852dc7e8c65a8e2eab6b32f552fd7f4fc6f152e76
+        sourceBlobDigest: sha256:feb2a952c0f5757a656e8fed5614e28bc4da195cbeb548b5aaf4fc09aee4ddac
         outLocation: /Users/gaspard/public-mistral/client-python
 workflow:
     workflowVersion: 1.0.0

--- a/docs/models/deltamessage.md
+++ b/docs/models/deltamessage.md
@@ -6,5 +6,5 @@
 | Field                                          | Type                                           | Required                                       | Description                                    |
 | ---------------------------------------------- | ---------------------------------------------- | ---------------------------------------------- | ---------------------------------------------- |
 | `role`                                         | *Optional[str]*                                | :heavy_minus_sign:                             | N/A                                            |
-| `content`                                      | *Optional[str]*                                | :heavy_minus_sign:                             | N/A                                            |
+| `content`                                      | *OptionalNullable[str]*                        | :heavy_minus_sign:                             | N/A                                            |
 | `tool_calls`                                   | List[[models.ToolCall](../models/toolcall.md)] | :heavy_minus_sign:                             | N/A                                            |

--- a/examples/async_jobs.py
+++ b/examples/async_jobs.py
@@ -10,9 +10,7 @@ from mistralai.models import File, TrainingParametersIn
 async def main():
     api_key = os.environ["MISTRAL_API_KEY"]
 
-    client = Mistral(
-        api_key="gpN4hC0YOSdZoBbzRcWNyALyMnNOT9jj", server_url="http://0.0.0.0:8882/"
-    )
+    client = Mistral(api_key=api_key)
 
     # Create new files
     with open("examples/file.jsonl", "rb") as f:

--- a/packages/mistralai_azure/.speakeasy/gen.lock
+++ b/packages/mistralai_azure/.speakeasy/gen.lock
@@ -1,12 +1,12 @@
 lockVersion: 2.0.0
 id: dc40fa48-2c4d-46ad-ac8b-270749770f34
 management:
-  docChecksum: 0f6edfd8ad8df6c49b3d429d1af7b9e2
+  docChecksum: 9128fabc3ae45ecc9ed7fae8991b3d3e
   docVersion: 0.0.2
-  speakeasyVersion: 1.372.0
+  speakeasyVersion: 1.373.1
   generationVersion: 2.399.0
-  releaseVersion: 1.0.0-rc.7
-  configChecksum: d14083a6bfd01e2d81264338ac4ed619
+  releaseVersion: 1.0.1
+  configChecksum: dc28e30e8f503aee23a53bb77a46c902
   published: true
 features:
   python:

--- a/packages/mistralai_azure/.speakeasy/gen.yaml
+++ b/packages/mistralai_azure/.speakeasy/gen.yaml
@@ -12,7 +12,7 @@ generation:
   auth:
     oAuth2ClientCredentialsEnabled: true
 python:
-  version: 1.0.0-rc.7
+  version: 1.0.1
   additionalDependencies:
     dev:
       pytest: ^8.2.2

--- a/packages/mistralai_azure/docs/models/deltamessage.md
+++ b/packages/mistralai_azure/docs/models/deltamessage.md
@@ -6,5 +6,5 @@
 | Field                                          | Type                                           | Required                                       | Description                                    |
 | ---------------------------------------------- | ---------------------------------------------- | ---------------------------------------------- | ---------------------------------------------- |
 | `role`                                         | *Optional[str]*                                | :heavy_minus_sign:                             | N/A                                            |
-| `content`                                      | *Optional[str]*                                | :heavy_minus_sign:                             | N/A                                            |
+| `content`                                      | *OptionalNullable[str]*                        | :heavy_minus_sign:                             | N/A                                            |
 | `tool_calls`                                   | List[[models.ToolCall](../models/toolcall.md)] | :heavy_minus_sign:                             | N/A                                            |

--- a/packages/mistralai_azure/pyproject.toml
+++ b/packages/mistralai_azure/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mistralai_azure"
-version = "1.0.0-rc.7"
+version = "1.0.1"
 description = "Python Client SDK for the Mistral AI API in Azure."
 authors = ["Mistral",]
 readme = "README-PYPI.md"

--- a/packages/mistralai_azure/src/mistralai_azure/models/deltamessage.py
+++ b/packages/mistralai_azure/src/mistralai_azure/models/deltamessage.py
@@ -10,19 +10,19 @@ from typing_extensions import NotRequired
 
 class DeltaMessageTypedDict(TypedDict):
     role: NotRequired[str]
-    content: NotRequired[str]
+    content: NotRequired[Nullable[str]]
     tool_calls: NotRequired[Nullable[List[ToolCallTypedDict]]]
     
 
 class DeltaMessage(BaseModel):
     role: Optional[str] = None
-    content: Optional[str] = None
+    content: OptionalNullable[str] = UNSET
     tool_calls: OptionalNullable[List[ToolCall]] = UNSET
     
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
         optional_fields = ["role", "content", "tool_calls"]
-        nullable_fields = ["tool_calls"]
+        nullable_fields = ["content", "tool_calls"]
         null_default_fields = []
 
         serialized = handler(self)

--- a/packages/mistralai_azure/src/mistralai_azure/sdkconfiguration.py
+++ b/packages/mistralai_azure/src/mistralai_azure/sdkconfiguration.py
@@ -29,9 +29,9 @@ class SDKConfiguration:
     server: Optional[str] = ""
     language: str = "python"
     openapi_doc_version: str = "0.0.2"
-    sdk_version: str = "1.0.0-rc.7"
+    sdk_version: str = "1.0.1"
     gen_version: str = "2.399.0"
-    user_agent: str = "speakeasy-sdk/python 1.0.0-rc.7 2.399.0 0.0.2 mistralai_azure"
+    user_agent: str = "speakeasy-sdk/python 1.0.1 2.399.0 0.0.2 mistralai_azure"
     retry_config: OptionalNullable[RetryConfig] = Field(default_factory=lambda: UNSET)
     timeout_ms: Optional[int] = None
 

--- a/packages/mistralai_gcp/.speakeasy/gen.lock
+++ b/packages/mistralai_gcp/.speakeasy/gen.lock
@@ -1,12 +1,12 @@
 lockVersion: 2.0.0
 id: ec60f2d8-7869-45c1-918e-773d41a8cf74
 management:
-  docChecksum: 4cc6e7c5c5ba15491872c600d4a247ef
+  docChecksum: b276b71cb6764f11b10461fe70962781
   docVersion: 0.0.2
-  speakeasyVersion: 1.372.0
+  speakeasyVersion: 1.373.1
   generationVersion: 2.399.0
-  releaseVersion: 1.0.0-rc.8
-  configChecksum: 1830c00a5e810fe954553fe55fdf9b71
+  releaseVersion: 1.0.1
+  configChecksum: 698bd633a47a664d6f3515c1b9ecdbaa
   published: true
 features:
   python:

--- a/packages/mistralai_gcp/.speakeasy/gen.yaml
+++ b/packages/mistralai_gcp/.speakeasy/gen.yaml
@@ -12,7 +12,7 @@ generation:
   auth:
     oAuth2ClientCredentialsEnabled: true
 python:
-  version: 1.0.0-rc.8
+  version: 1.0.1
   additionalDependencies:
     dev:
       pytest: ^8.2.2

--- a/packages/mistralai_gcp/docs/models/deltamessage.md
+++ b/packages/mistralai_gcp/docs/models/deltamessage.md
@@ -6,5 +6,5 @@
 | Field                                          | Type                                           | Required                                       | Description                                    |
 | ---------------------------------------------- | ---------------------------------------------- | ---------------------------------------------- | ---------------------------------------------- |
 | `role`                                         | *Optional[str]*                                | :heavy_minus_sign:                             | N/A                                            |
-| `content`                                      | *Optional[str]*                                | :heavy_minus_sign:                             | N/A                                            |
+| `content`                                      | *OptionalNullable[str]*                        | :heavy_minus_sign:                             | N/A                                            |
 | `tool_calls`                                   | List[[models.ToolCall](../models/toolcall.md)] | :heavy_minus_sign:                             | N/A                                            |

--- a/packages/mistralai_gcp/pyproject.toml
+++ b/packages/mistralai_gcp/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mistralai-gcp"
-version = "1.0.0-rc.8"
+version = "1.0.1"
 description = "Python Client SDK for the Mistral AI API in GCP."
 authors = ["Mistral",]
 readme = "README-PYPI.md"

--- a/packages/mistralai_gcp/src/mistralai_gcp/models/deltamessage.py
+++ b/packages/mistralai_gcp/src/mistralai_gcp/models/deltamessage.py
@@ -10,19 +10,19 @@ from typing_extensions import NotRequired
 
 class DeltaMessageTypedDict(TypedDict):
     role: NotRequired[str]
-    content: NotRequired[str]
+    content: NotRequired[Nullable[str]]
     tool_calls: NotRequired[Nullable[List[ToolCallTypedDict]]]
     
 
 class DeltaMessage(BaseModel):
     role: Optional[str] = None
-    content: Optional[str] = None
+    content: OptionalNullable[str] = UNSET
     tool_calls: OptionalNullable[List[ToolCall]] = UNSET
     
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
         optional_fields = ["role", "content", "tool_calls"]
-        nullable_fields = ["tool_calls"]
+        nullable_fields = ["content", "tool_calls"]
         null_default_fields = []
 
         serialized = handler(self)

--- a/packages/mistralai_gcp/src/mistralai_gcp/sdkconfiguration.py
+++ b/packages/mistralai_gcp/src/mistralai_gcp/sdkconfiguration.py
@@ -29,9 +29,9 @@ class SDKConfiguration:
     server: Optional[str] = ""
     language: str = "python"
     openapi_doc_version: str = "0.0.2"
-    sdk_version: str = "1.0.0-rc.8"
+    sdk_version: str = "1.0.1"
     gen_version: str = "2.399.0"
-    user_agent: str = "speakeasy-sdk/python 1.0.0-rc.8 2.399.0 0.0.2 mistralai-gcp"
+    user_agent: str = "speakeasy-sdk/python 1.0.1 2.399.0 0.0.2 mistralai-gcp"
     retry_config: OptionalNullable[RetryConfig] = Field(default_factory=lambda: UNSET)
     timeout_ms: Optional[int] = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mistralai"
-version = "1.1.3"
+version = "1.0.1"
 description = "Python Client SDK for the Mistral AI API."
 authors = ["Mistral"]
 readme = "README.md"

--- a/src/mistralai/models/deltamessage.py
+++ b/src/mistralai/models/deltamessage.py
@@ -10,19 +10,19 @@ from typing_extensions import NotRequired
 
 class DeltaMessageTypedDict(TypedDict):
     role: NotRequired[str]
-    content: NotRequired[str]
+    content: NotRequired[Nullable[str]]
     tool_calls: NotRequired[Nullable[List[ToolCallTypedDict]]]
     
 
 class DeltaMessage(BaseModel):
     role: Optional[str] = None
-    content: Optional[str] = None
+    content: OptionalNullable[str] = UNSET
     tool_calls: OptionalNullable[List[ToolCall]] = UNSET
     
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
         optional_fields = ["role", "content", "tool_calls"]
-        nullable_fields = ["tool_calls"]
+        nullable_fields = ["content", "tool_calls"]
         null_default_fields = []
 
         serialized = handler(self)

--- a/src/mistralai/sdkconfiguration.py
+++ b/src/mistralai/sdkconfiguration.py
@@ -29,9 +29,9 @@ class SDKConfiguration:
     server: Optional[str] = ""
     language: str = "python"
     openapi_doc_version: str = "0.0.2"
-    sdk_version: str = "1.1.3"
+    sdk_version: str = "1.0.1"
     gen_version: str = "2.399.0"
-    user_agent: str = "speakeasy-sdk/python 1.1.3 2.399.0 0.0.2 mistralai"
+    user_agent: str = "speakeasy-sdk/python 1.0.1 2.399.0 0.0.2 mistralai"
     retry_config: OptionalNullable[RetryConfig] = Field(default_factory=lambda: UNSET)
     timeout_ms: Optional[int] = None
 


### PR DESCRIPTION
This PR updates the client to accepts `"content": null` when returning tool call in streaming
Files of interest:
- [azure](https://github.com/mistralai/client-python/compare/gaspardBT/fix-empty-content?expand=1#diff-66bec9d83dfea88fe7e172ec906084ede53864d9598093d5baf730f8735e88ad)
- [gcp](https://github.com/mistralai/client-python/compare/gaspardBT/fix-empty-content?expand=1#diff-7213ad24d5d4fb1c4aa4b2e1a5284d854195873e68cefae8ceb6ccfd85921256)
- [laPlateforme](https://github.com/mistralai/client-python/compare/gaspardBT/fix-empty-content?expand=1#diff-66d95fce76e44420db23c49f0637cac5b10ed2db4434248741188dfe3f6bcb95)