### PR TITLE
Use spec with tag main for generation

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -3,19 +3,19 @@ speakeasyVersion: latest
 sources:
     mistral-azure-source:
         inputs:
-            - location: registry.speakeasyapi.dev/mistral-dev/mistral-dev/mistral-openapi-azure
+            - location: registry.speakeasyapi.dev/mistral-dev/mistral-dev/mistral-openapi-azure:main
         registry:
-            location: registry.speakeasyapi.dev/mistral-dev/mistral-dev/mistral-openapi-azure
+            location: registry.speakeasyapi.dev/mistral-dev/mistral-dev/mistral-openapi-azure:main
     mistral-google-cloud-source:
         inputs:
-            - location: registry.speakeasyapi.dev/mistral-dev/mistral-dev/mistral-openapi-google-cloud
+            - location: registry.speakeasyapi.dev/mistral-dev/mistral-dev/mistral-openapi-google-cloud:main
         registry:
-            location: registry.speakeasyapi.dev/mistral-dev/mistral-dev/mistral-openapi-google-cloud
+            location: registry.speakeasyapi.dev/mistral-dev/mistral-dev/mistral-openapi-google-cloud:main
     mistral-openapi:
         inputs:
-            - location: registry.speakeasyapi.dev/mistral-dev/mistral-dev/mistral-openapi
+            - location: registry.speakeasyapi.dev/mistral-dev/mistral-dev/mistral-openapi:main
         registry:
-            location: registry.speakeasyapi.dev/mistral-dev/mistral-dev/mistral-openapi
+            location: registry.speakeasyapi.dev/mistral-dev/mistral-dev/mistral-openapi:main
 targets:
     mistralai-azure-sdk:
         target: python


### PR DESCRIPTION
This PR makes the workflow target the latest spec with the `main` tag for code generation