### PR TITLE
[Github Actions] Pin `poetry` to `1.8.5` to avoid `speakeasy run` failure.

### DIFF
--- a/.github/workflows/sdk_generation_mistralai_azure_sdk.yaml
+++ b/.github/workflows/sdk_generation_mistralai_azure_sdk.yaml
@@ -20,6 +20,9 @@ jobs:
     with:
       force: ${{ github.event.inputs.force }}
       mode: pr
+      # We need poetry < 2.0 to avoid the speakeasy run failure.
+      # This was fixed in speakasy v1.467.0 but we're locked at 1.462.2 waiting for other speakeasy fixes.
+      poetry_version: 1.8.5
       set_version: ${{ github.event.inputs.set_version }}
       speakeasy_version: latest
       target: mistral-python-sdk-azure

--- a/.github/workflows/sdk_generation_mistralai_gcp_sdk.yaml
+++ b/.github/workflows/sdk_generation_mistralai_gcp_sdk.yaml
@@ -20,6 +20,9 @@ jobs:
     with:
       force: ${{ github.event.inputs.force }}
       mode: pr
+      # We need poetry < 2.0 to avoid the speakeasy run failure.
+      # This was fixed in speakasy v1.467.0 but we're locked at 1.462.2 waiting for other speakeasy fixes.
+      poetry_version: 1.8.5
       set_version: ${{ github.event.inputs.set_version }}
       speakeasy_version: latest
       target: mistral-python-sdk-google-cloud

--- a/.github/workflows/sdk_generation_mistralai_sdk.yaml
+++ b/.github/workflows/sdk_generation_mistralai_sdk.yaml
@@ -20,6 +20,9 @@ jobs:
     with:
       force: ${{ github.event.inputs.force }}
       mode: pr
+      # We need poetry < 2.0 to avoid the speakeasy run failure.
+      # This was fixed in speakasy v1.467.0 but we're locked at 1.462.2 waiting for other speakeasy fixes.
+      poetry_version: 1.8.5
       set_version: ${{ github.event.inputs.set_version }}
       speakeasy_version: latest
       target: mistralai-sdk

--- a/.github/workflows/sdk_publish_mistralai_sdk.yaml
+++ b/.github/workflows/sdk_publish_mistralai_sdk.yaml
@@ -14,6 +14,10 @@ permissions:
 jobs:
   publish:
     uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v15
+    with:
+      # We need poetry < 2.0 to avoid the speakeasy run failure.
+      # This was fixed in speakasy v1.467.0 but we're locked at 1.462.2 waiting for other speakeasy fixes.
+      poetry_version: 1.8.5
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       pypi_token: ${{ secrets.PYPI_TOKEN }}

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,5 +1,8 @@
 workflowVersion: 1.0.0
-speakeasyVersion: 1.462.2 # # Pinned to unblock https://github.com/mistralai/client-python/pull/173
+# speakeasyVersion is pinned to unblock https://github.com/mistralai/client-python/pull/173
+# The speakeasy run was appending `_` to some attributes to avoid conflicts with reserved keywords.
+# This would have change the SDK APIs and break the existing clients which we don't want.
+speakeasyVersion: 1.462.2
 sources:
     mistral-azure-source:
         inputs:


### PR DESCRIPTION
The `Generate MISTRALAI` workflow [has been failing with](https://github.com/mistralai/client-python/actions/runs/12785375797/job/35640240514):
```
  » Compile SDK...
                  
  Step: Compile SDK started
  INFO    Running command: poetry version 1.3.1	{"path":"/github/workspace/repo"}
  INFO    Running command: poetry lock --no-update	{"path":"/github/workspace/repo"}
  WARN    failed running commands: 
  
  Creating virtualenv mistralai in /github/workspace/repo/.venv
  
  The option "--no-update" does not exist
```
This issue was fixed in [speakasy v1.467.0](https://github.com/speakeasy-api/speakeasy/releases/tag/v1.467.0) but we're locked at `speakeasy v1.462.2` because it was appending `_` to attributes changing to much our SDK.

The error is coming from poetry that deprecated the `--no-update` flag, hence pinning poetry to `1.8.5` should solve the issue.
