### PR TITLE
fix: Don't sort json schema when using marshal_json

### DIFF
--- a/src/mistralai/utils/serializers.py
+++ b/src/mistralai/utils/serializers.py
@@ -163,7 +163,7 @@ def marshal_json(val, typ):
     if len(d) == 0:
         return ""
 
-    return json.dumps(d[next(iter(d))], separators=(",", ":"), sort_keys=True)
+    return json.dumps(d[next(iter(d))], separators=(",", ":"), sort_keys=False)
 
 
 def is_nullable(field):


### PR DESCRIPTION
When using [Custom Structured Outputs](https://docs.mistral.ai/capabilities/structured-output/custom_structured_output/), the Pydantic model is transformed into a JSON schema, which keeps the order of the fields of the model, _until_ the function `marshal_json` is used, which sorts all the fields in alphabetical order.

Changing the order of the fields of the model makes using structured outputs unpractical when order in which fields are generated is important (for example, when using thinking/reasoning).