### PR TITLE
chore: pyproject update

### DIFF
--- a/.github/workflows/run_example_scripts.yaml
+++ b/.github/workflows/run_example_scripts.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
       - name: Checkout code
@@ -27,8 +27,6 @@ jobs:
 
       - name: Install Poetry
         uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
-        with:
-          version: ${{ matrix.python-version == '3.8' && '1.8.5' || '2.1.1' }}
 
       - name: Build and install client
         run: |

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,5 +1,5 @@
 workflowVersion: 1.0.0
-speakeasyVersion: 1.477.0
+speakeasyVersion:  1.517.3
 sources:
     mistral-azure-source:
         inputs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,19 @@
-[tool.poetry]
+[project]
 name = "mistralai"
 version = "1.5.2"
 description = "Python Client SDK for the Mistral AI API."
-authors = ["Mistral"]
+authors = [{ name = "Mistral" },]
 readme = "README-PYPI.md"
+requires-python = ">=3.9"
+dependencies = [
+    "eval-type-backport >=0.2.0",
+    "httpx >=0.28.1",
+    "pydantic >=2.10.3",
+    "python-dateutil >=2.8.2",
+    "typing-inspection >=0.4.0",
+]
+
+[tool.poetry]
 repository = "https://github.com/mistralai/client-python.git"
 packages = [
     { include = "mistralai", from = "src" },
@@ -18,32 +28,25 @@ include = ["py.typed", "src/mistralai/py.typed"]
 [virtualenvs]
 in-project = true
 
-[tool.poetry.dependencies]
-python = ">=3.8"
-eval-type-backport = ">=0.2.0"
-httpx = ">=0.27.0"
-jsonpath-python = ">=1.0.6"
-pydantic = ">=2.9.0"
-python-dateutil = ">=2.8.2"
-typing-inspect = ">=0.9.0"
-google-auth = { version = ">=2.27.0", optional = true }
-requests = { version = ">=2.32.3", optional = true }
-
 [tool.poetry.group.dev.dependencies]
-mypy = ">=1.13.0"
-pylint = ">=3.2.3"
-pytest = ">=8.2.2"
-pytest-asyncio = ">=0.23.7"
-types-python-dateutil = ">=2.9.0.20240316"
+mypy = "==1.14.1"
+pylint = "==3.2.3"
+pytest = "^8.2.2"
+pytest-asyncio = "^0.23.7"
+types-python-dateutil = "^2.9.0.20240316"
 
-[tool.poetry.extras]
-gcp = ["google-auth", "requests"]
+[project.optional-dependencies]
+gcp = [
+    "google-auth >=2.27.0",
+    "requests >=2.32.3"
+]
 
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 pythonpath = ["src"]
 
 [tool.mypy]


### PR DESCRIPTION
This PR:
- pins the speakeasy to 1.517.3
- updates pyproject to match the one generated by speakeasy
- drops support for python 3.9

This will re commit the changes from both 81f02dd942fb404d1afb8614a2f21e764a0e9487 and 32ff73893b9156f290b447da2a191ae9be4e184d

The CI failures for the examples are expected as the code haven't been updated yet to match the pyproject (next PR)
