### PR TITLE
Speakeasy created PR should trigger the test workflow

### DIFF
--- a/.github/workflows/sdk_generation_mistralai_sdk.yaml
+++ b/.github/workflows/sdk_generation_mistralai_sdk.yaml
@@ -24,6 +24,6 @@ jobs:
       speakeasy_version: latest
       target: mistralai-sdk
     secrets:
-      github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      github_access_token: ${{ secrets.SPEAKEASY_WORKFLOW_GITHUB_PAT }}
       pypi_token: ${{ secrets.PYPI_TOKEN }}
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}


### PR DESCRIPTION
From Github's doc [Triggering a workflow from a workflow](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow):
```
If you do want to trigger a workflow from within a workflow run, you can use a GitHub App installation access token or a personal access token instead of GITHUB_TOKEN to trigger events that require a token.
```
