### PR TITLE
Fix unhashable exception SDKError

### DIFF
--- a/packages/mistralai_azure/src/mistralai_azure/models/sdkerror.py
+++ b/packages/mistralai_azure/src/mistralai_azure/models/sdkerror.py
@@ -5,7 +5,7 @@ from typing import Optional
 import httpx
 
 
-@dataclass
+@dataclass(frozen=True)
 class SDKError(Exception):
     """Represents an error returned by the API."""
 


### PR DESCRIPTION
Hi 👋 

A small PR for an issue I recently go with the SDKError exception class.

# Context

To monitor and process exceptions are often mapped as dictionary or set. I recently encounter the following issue using the mistral Python client and Rollbar : 

```
TypeError("unhashable type: 'SDKError'")
```

This means, I got an exception using the mistral library and I'm not aware of it because the exception is not sent to Rollbar.

# Bug reproduction

Just do : 
```
error = SDKError("", 0, "")
print({error})
```

It will fail. Then add `frozen=True` like in the PR and it will work well.

Here is where an exception is mapped as a set in Rollbar : https://github.com/rollbar/pyrollbar/blob/84efba4ae3c9a5faef60b3bed3856f27940a0964/rollbar/__init__.py#L817


