### PR TITLE
chore: Enable new changelog in PR Message, Commit Message, Release Notes

### DIFF
--- a/.github/workflows/sdk_generation_mistralai_azure_sdk.yaml
+++ b/.github/workflows/sdk_generation_mistralai_azure_sdk.yaml
@@ -23,6 +23,7 @@ jobs:
       set_version: ${{ github.event.inputs.set_version }}
       speakeasy_version: latest
       target: mistral-python-sdk-azure
+      enable_sdk_changelog_july_2025: true
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       pypi_token: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/sdk_generation_mistralai_gcp_sdk.yaml
+++ b/.github/workflows/sdk_generation_mistralai_gcp_sdk.yaml
@@ -23,6 +23,7 @@ jobs:
       set_version: ${{ github.event.inputs.set_version }}
       speakeasy_version: latest
       target: mistral-python-sdk-google-cloud
+      enable_sdk_changelog_july_2025: true
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       pypi_token: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/sdk_generation_mistralai_sdk.yaml
+++ b/.github/workflows/sdk_generation_mistralai_sdk.yaml
@@ -23,6 +23,7 @@ jobs:
       set_version: ${{ github.event.inputs.set_version }}
       speakeasy_version: latest
       target: mistralai-sdk
+      enable_sdk_changelog_july_2025: true
     secrets:
       github_access_token: ${{ secrets.SPEAKEASY_WORKFLOW_GITHUB_PAT }}
       pypi_token: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/sdk_publish_mistralai_sdk.yaml
+++ b/.github/workflows/sdk_publish_mistralai_sdk.yaml
@@ -14,6 +14,8 @@ permissions:
 jobs:
   publish:
     uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v15
+    with:
+      enable_sdk_changelog_july_2025: true
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       pypi_token: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
## PR to enable new changelog from Speakeasy.
**The new changelog more accurately captures the changes introduced in the SDK by  Speakeasy (highlighted in the screenshot)**

<img width="882" height="830" alt="new changelog v1" src="https://github.com/user-attachments/assets/2e2e8df2-9b07-422d-b671-2a17de18047d" />