### PR TITLE
replaced manual comparison with direct slice comparison

### DIFF
--- a/src/mistralai/utils/eventstreaming.py
+++ b/src/mistralai/utils/eventstreaming.py
@@ -238,11 +238,9 @@ def _parse_event(
 
 
 def _peek_sequence(position: int, buffer: bytearray, sequence: bytes):
-    if len(sequence) > (len(buffer) - position):
+    buffer_len = len(buffer)
+    seq_len = len(sequence)
+    if position + seq_len > buffer_len:
         return None
-
-    for i, seq in enumerate(sequence):
-        if buffer[position + i] != seq:
-            return None
-
-    return sequence
+    view = memoryview(buffer)
+    return sequence if view[position:position + seq_len] == sequence else None


### PR DESCRIPTION
Used `memoryview` to create a zero copy view of the buffer, avoiding memory allocation for slices. This optimized version should be significantly faster for longer sequences.