### PR TITLE
fix: support numeric values in JSON schema for Pydantic constrained types

### DIFF
--- a/src/mistralai/extra/tests/test_utils.py
+++ b/src/mistralai/extra/tests/test_utils.py
@@ -3,7 +3,7 @@ from ..utils.response_format import (
     response_format_from_pydantic_model,
     rec_strict_json_schema,
 )
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, ValidationError, conlist
 
 from ...models import ResponseFormat, JSONSchema
 from ...types.basemodel import Unset
@@ -24,6 +24,11 @@ class Explanation(BaseModel):
 class MathDemonstration(BaseModel):
     steps: list[Explanation]
     final_answer: str
+
+
+class ConlistModel(BaseModel):
+    """Model with constrained list to test numeric values in schema"""
+    words: conlist(str, min_length=3, max_length=5)  # type: ignore
 
 
 mathdemo_schema = {
@@ -149,13 +154,26 @@ class TestResponseFormat(unittest.TestCase):
         )
 
     def test_rec_strict_json_schema(self):
-        invalid_schema = mathdemo_schema | {"wrong_value": 1}
+        # Test that numeric values (like constraints) are now handled correctly
+        schema_with_numeric = mathdemo_schema | {"numeric_value": 42, "float_value": 3.14}
         self.assertEqual(
             rec_strict_json_schema(mathdemo_schema), mathdemo_strict_schema
         )
 
-        with self.assertRaises(ValueError):
-            rec_strict_json_schema(invalid_schema)
+        # Numeric values should now be accepted as valid schema values
+        result = rec_strict_json_schema(schema_with_numeric)
+        self.assertEqual(result["numeric_value"], 42)
+        self.assertEqual(result["float_value"], 3.14)
+
+    def test_conlist_schema(self):
+        """Test that Pydantic models with conlist work correctly (issue #279)"""
+        # This should not raise a ValueError
+        response_format = response_format_from_pydantic_model(ConlistModel)
+
+        # Verify the response format was created successfully
+        self.assertIsNotNone(response_format)
+        self.assertEqual(response_format.json_schema.name, "ConlistModel")
+        self.assertTrue(response_format.json_schema.strict)
 
 
 if __name__ == "__main__":

--- a/src/mistralai/extra/utils/_pydantic_helper.py
+++ b/src/mistralai/extra/utils/_pydantic_helper.py
@@ -6,7 +6,7 @@ def rec_strict_json_schema(schema_node: Any) -> Any:
     Recursively set the additionalProperties property to False for all objects in the JSON Schema.
     This makes the JSON Schema strict (i.e. no additional properties are allowed).
     """
-    if isinstance(schema_node, (str, bool)) or schema_node is None:
+    if isinstance(schema_node, (str, bool, int, float)) or schema_node is None:
         return schema_node
     if isinstance(schema_node, dict):
         if "type" in schema_node and schema_node["type"] == "object":


### PR DESCRIPTION
## Summary
Fixes #279 - Adds support for Pydantic constrained types like `conlist`, `conset`, etc. that include numeric constraint values in their JSON schemas.

## Problem
The `rec_strict_json_schema` function in `_pydantic_helper.py` was raising a `ValueError` when encountering numeric values (int, float) in JSON schemas. This prevented the use of Pydantic models with constrained types like `conlist`, which generate schemas with numeric constraints such as `minItems` and `maxItems`.

## Solution
Updated `rec_strict_json_schema` to treat numeric types (int, float) as valid primitive values, similar to strings and booleans. These values are passed through unchanged during schema processing.

## Changes
- ✅ Modified `rec_strict_json_schema` to accept `int` and `float` as valid primitive types
- ✅ Updated `test_rec_strict_json_schema` to verify numeric values are handled correctly
- ✅ Added `test_conlist_schema` to specifically test Pydantic conlist compatibility with minItems/maxItems constraints

## Testing
Tested with the exact reproduction case from issue #279:
```python
from pydantic import BaseModel, conlist
from mistralai.extra.utils.response_format import response_format_from_pydantic_model

class ExampleModel(BaseModel):
    words: conlist(str, min_length=3, max_length=3)

# Previously raised ValueError, now works correctly
response_format = response_format_from_pydantic_model(ExampleModel)
```

The fix ensures that JSON schemas with numeric constraint values (like `minItems: 3`, `maxItems: 5`) are properly processed without errors.