### PR TITLE
fix: function_calling.py to check all transactions before returning error

### DIFF
--- a/examples/mistral/chat/function_calling.py
+++ b/examples/mistral/chat/function_calling.py
@@ -29,16 +29,14 @@ def retrieve_payment_status(data: Dict[str, List], transaction_id: str) -> str:
     for i, r in enumerate(data["transaction_id"]):
         if r == transaction_id:
             return json.dumps({"status": data["payment_status"][i]})
-        else:
-            return json.dumps({"status": "Error - transaction id not found"})
+    return json.dumps({"status": "Error - transaction id not found"})
 
 
 def retrieve_payment_date(data: Dict[str, List], transaction_id: str) -> str:
     for i, r in enumerate(data["transaction_id"]):
         if r == transaction_id:
             return json.dumps({"date": data["payment_date"][i]})
-        else:
-            return json.dumps({"status": "Error - transaction id not found"})
+    return json.dumps({"status": "Error - transaction id not found"})
 
 
 names_to_functions = {


### PR DESCRIPTION
I believe the functions only check the the first transaction, due to else within the for loop, and so return the error too soon. Appreciate this is a very minor point. 