### PR TITLE
Fix GCP hook: preserve httpx request extensions (timeout_ms)

### DIFF
--- a/packages/mistralai_gcp/src/mistralai_gcp/sdk.py
+++ b/packages/mistralai_gcp/src/mistralai_gcp/sdk.py
@@ -226,6 +226,7 @@ class GoogleCloudBeforeRequestHook(BeforeRequestHook):
             headers=headers,
             content=new_content,
             stream=None,
+            extensions=request.extensions,
         )
 
         return next_request

--- a/src/mistralai/extra/tests/test_gcp_timeout_extensions.py
+++ b/src/mistralai/extra/tests/test_gcp_timeout_extensions.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+import httpx
+
+# Add the mistralai_gcp package to the path for imports
+gcp_package_path = Path(__file__).parent.parent.parent.parent.parent / "packages" / "mistralai_gcp" / "src"
+sys.path.insert(0, str(gcp_package_path))
+
+from mistralai_gcp.sdk import GoogleCloudBeforeRequestHook
+
+def test_gcp_before_request_preserves_timeout_extension():
+    hook = GoogleCloudBeforeRequestHook(region="europe-west4", project_id="proj")
+
+    req = httpx.Request(
+        "POST",
+        "https://europe-west4-aiplatform.googleapis.com/v1/dummy",
+        content=b'{"model":"mistral-large-2407"}',
+        headers={"content-type": "application/json"},
+    )
+    timeout = httpx.Timeout(30.0)
+    req.extensions["timeout"] = timeout
+
+    out = hook.before_request(None, req)
+    assert isinstance(out, httpx.Request)
+    assert out.extensions.get("timeout") == timeout


### PR DESCRIPTION
Fixes #253 
Root cause
`GoogleCloudBeforeRequestHook.before_request` rebuilds an `httpx.Request` without forwarding `request.extensions`. httpx stores per-request timeout configuration in `extensions`, so `timeout_ms` is dropped and the default timeout is used.

Change

* Preserve `request.extensions` when creating `next_request` by passing `extensions=request.extensions`.

Tests

* Added regression test `src/mistralai/extra/tests/test_gcp_timeout_extensions.py` asserting the `timeout` extension is preserved through the hook.
