### PR TITLE
Fix rec_strict_json_schema to handle numeric constraint keywords

### DIFF
--- a/src/mistralai/extra/utils/_pydantic_helper.py
+++ b/src/mistralai/extra/utils/_pydantic_helper.py
@@ -6,7 +6,9 @@ def rec_strict_json_schema(schema_node: Any) -> Any:
     Recursively set the additionalProperties property to False for all objects in the JSON Schema.
     This makes the JSON Schema strict (i.e. no additional properties are allowed).
     """
-    if isinstance(schema_node, (str, bool)) or schema_node is None:
+    # Include int and float as terminal types to handle JSON Schema constraint keywords
+    # like minLength, maxLength, minItems, maxItems, minimum, maximum, etc.
+    if isinstance(schema_node, (str, bool, int, float)) or schema_node is None:
         return schema_node
     if isinstance(schema_node, dict):
         if "type" in schema_node and schema_node["type"] == "object":


### PR DESCRIPTION
## Summary
- Fixed `rec_strict_json_schema` function to handle `int` and `float` values as terminal types
- This fixes issue #300 where Pydantic models with constraint keywords like `min_length`, `max_length`, `minItems`, `maxItems`, `minimum`, `maximum`, and `multipleOf` would cause a `ValueError`

## Problem
When using `response_format_from_pydantic_model()` with Pydantic models that have constraint keywords (like `Field(min_length=1)`), the `rec_strict_json_schema()` function was raising a `ValueError` because it only considered `str` and `bool` as valid terminal types, but JSON Schema constraint keywords have numeric values (`int` or `float`).

Example that failed:
```python
from pydantic import BaseModel, Field
from mistralai.extra.utils.response_format import response_format_from_pydantic_model

class ModelWithConstraints(BaseModel):
    items: list[int] = Field(min_length=1)
    name: str = Field(min_length=1, max_length=100)

# This raised ValueError: Unexpected type: 1
response_format = response_format_from_pydantic_model(ModelWithConstraints)
```

## Solution
Added `int` and `float` to the type check in `rec_strict_json_schema()`:
```python
if isinstance(schema_node, (str, bool, int, float)) or schema_node is None:
    return schema_node
```

## Test plan
- [x] Added test for `rec_strict_json_schema` with numeric constraints (`minItems`, `maxItems`, `minLength`, `maxLength`, `minimum`, `maximum`, `multipleOf`)
- [x] Added test for `response_format_from_pydantic_model` with constrained Pydantic models
- [x] Added test to verify invalid types still raise `ValueError`

Fixes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)