### PR TITLE
chore: update speakeasy-api/sdk-generation-action reference

### DIFF
--- a/.github/workflows/sdk_generation_mistralai_azure_sdk.yaml
+++ b/.github/workflows/sdk_generation_mistralai_azure_sdk.yaml
@@ -16,7 +16,7 @@ permissions:
         type: string
 jobs:
   generate:
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@5b268931ef6902bbb70fa01b467dc361c68f7617 # v15
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@a658ca0a4a9b11bbcd7d3fb4e3063fa843afabff # v15
     with:
       force: ${{ github.event.inputs.force }}
       mode: pr

--- a/.github/workflows/sdk_generation_mistralai_gcp_sdk.yaml
+++ b/.github/workflows/sdk_generation_mistralai_gcp_sdk.yaml
@@ -16,7 +16,7 @@ permissions:
         type: string
 jobs:
   generate:
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@5b268931ef6902bbb70fa01b467dc361c68f7617 # v15
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@a658ca0a4a9b11bbcd7d3fb4e3063fa843afabff # v15
     with:
       force: ${{ github.event.inputs.force }}
       mode: pr

--- a/.github/workflows/sdk_generation_mistralai_sdk.yaml
+++ b/.github/workflows/sdk_generation_mistralai_sdk.yaml
@@ -16,7 +16,7 @@ permissions:
         type: string
 jobs:
   generate:
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@5b268931ef6902bbb70fa01b467dc361c68f7617 # v15
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@a658ca0a4a9b11bbcd7d3fb4e3063fa843afabff # v15
     with:
       force: ${{ github.event.inputs.force }}
       mode: pr

--- a/.github/workflows/sdk_publish_mistralai_sdk.yaml
+++ b/.github/workflows/sdk_publish_mistralai_sdk.yaml
@@ -13,7 +13,7 @@ permissions:
       - "*/RELEASES.md"
 jobs:
   publish:
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@5b268931ef6902bbb70fa01b467dc361c68f7617 # v15
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@a658ca0a4a9b11bbcd7d3fb4e3063fa843afabff # v15
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       pypi_token: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Update the reference to the speakeasy-api/sdk-generation-action workflows to the latest version (a658ca0a4a9b11bbcd7d3fb4e3063fa843afabff) for all SDK generation workflows. This ensures the latest features and bug fixes are used during SDK generation.
