### PR TITLE
fix(otel): don't setup TracerProvider, rely on application config

### DIFF
--- a/src/mistralai/_hooks/tracing.py
+++ b/src/mistralai/_hooks/tracing.py
@@ -30,13 +30,30 @@ class TracingHook(BeforeRequestHook, AfterSuccessHook, AfterErrorHook):
     def before_request(
         self, hook_ctx: BeforeRequestContext, request: httpx.Request
     ) -> Union[httpx.Request, Exception]:
-        request, self.request_span = get_traced_request_and_span(tracing_enabled=self.tracing_enabled, tracer=self.tracer, span=self.request_span, operation_id=hook_ctx.operation_id, request=request)
+        # Refresh tracer/provider per request so tracing can be enabled if the
+        # application configures OpenTelemetry after the client is instantiated.
+        self.tracing_enabled, self.tracer = get_or_create_otel_tracer()
+        self.request_span = None
+        request, self.request_span = get_traced_request_and_span(
+            tracing_enabled=self.tracing_enabled,
+            tracer=self.tracer,
+            span=self.request_span,
+            operation_id=hook_ctx.operation_id,
+            request=request,
+        )
         return request
 
     def after_success(
         self, hook_ctx: AfterSuccessContext, response: httpx.Response
     ) -> Union[httpx.Response, Exception]:
-        response = get_traced_response(tracing_enabled=self.tracing_enabled, tracer=self.tracer, span=self.request_span, operation_id=hook_ctx.operation_id, response=response)
+        response = get_traced_response(
+            tracing_enabled=self.tracing_enabled,
+            tracer=self.tracer,
+            span=self.request_span,
+            operation_id=hook_ctx.operation_id,
+            response=response,
+        )
+        self.request_span = None
         return response
 
     def after_error(
@@ -46,5 +63,13 @@ class TracingHook(BeforeRequestHook, AfterSuccessHook, AfterErrorHook):
         error: Optional[Exception],
     ) -> Union[Tuple[Optional[httpx.Response], Optional[Exception]], Exception]:
         if response:
-            response, error = get_response_and_error(tracing_enabled=self.tracing_enabled, tracer=self.tracer, span=self.request_span, operation_id=hook_ctx.operation_id, response=response, error=error)
+            response, error = get_response_and_error(
+                tracing_enabled=self.tracing_enabled,
+                tracer=self.tracer,
+                span=self.request_span,
+                operation_id=hook_ctx.operation_id,
+                response=response,
+                error=error,
+            )
+        self.request_span = None
         return response, error


### PR DESCRIPTION
The SDK was creating its own TracerProvider when OTEL_EXPORTER_OTLP_ENDPOINT was set but no TracerProvider was configured. This caused issues when used in applications that configure their own TracerProvider:

1. The SDK's TracerProvider would be set first, preventing the app's setup
2. The endpoint was passed without /v1/traces path, causing 404 errors

Now the SDK follows OTEL best practices:
- Libraries/SDKs get tracers from the global provider
- Applications configure the TracerProvider
- If no provider is set, tracing is effectively disabled (NoOp)

This allows applications to control when and how OTEL is configured, and the SDK will automatically use whatever TracerProvider is available.

Removed:
- QuietOTLPSpanExporter class (no longer needed)
- OTEL_EXPORTER_OTLP_* constants (no longer used)
- TracerProvider setup logic