### PR TITLE
Fix missing dependency of the workflow on pyright

### DIFF
--- a/.github/workflows/update_speakeasy.yaml
+++ b/.github/workflows/update_speakeasy.yaml
@@ -102,7 +102,7 @@ jobs:
             --label speakeasy-update \
             --assignee ${{ github.actor }}
         env:
-          GITHUB_TOKEN: ${{ secrets.SPEAKEASY_WORKFLOW_GITHUB_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Comment on workflow run
         if: steps.check-changes.outputs.has_changes == 'false'

--- a/packages/mistralai_azure/pyproject.toml
+++ b/packages/mistralai_azure/pyproject.toml
@@ -19,11 +19,6 @@ dev = [
     "pytest>=8.2.2,<9",
     "pytest-asyncio>=0.23.7,<0.24",
 ]
-lint = [
-    "ruff>=0.11.10,<0.12",
-    "pyright>=1.1.401,<2",
-    "mypy==1.15.0",
-]
 
 [tool.setuptools.package-data]
 "*" = ["py.typed", "src/mistralai_azure/py.typed"]

--- a/packages/mistralai_gcp/pyproject.toml
+++ b/packages/mistralai_gcp/pyproject.toml
@@ -24,11 +24,6 @@ dev = [
     "pytest-asyncio>=0.23.7,<0.24",
     "types-python-dateutil>=2.9.0.20240316,<3",
 ]
-lint = [
-    "ruff>=0.11.10,<0.12",
-    "pyright>=1.1.401,<2",
-    "mypy==1.15.0",
-]
 
 [tool.setuptools.package-data]
 "*" = ["py.typed", "src/mistralai_gcp/py.typed"]


### PR DESCRIPTION
Changes:
* Added missing dependency on `pyright` in Azure/GCP's dev dependency groups
* Fixed the github token used to publish the pull request

Testing:
* Workflow execution: https://github.com/mistralai/client-python/actions/runs/20964466354
* Output PR: https://github.com/mistralai/client-python/pull/323