### PR TITLE
Allow the publish workflow to be triggered manually

### DIFF
--- a/.github/workflows/sdk_publish_mistralai_sdk.yaml
+++ b/.github/workflows/sdk_publish_mistralai_sdk.yaml
@@ -5,6 +5,7 @@ permissions:
   pull-requests: write
   statuses: write
 "on":
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
pyproject.toml is managed manually (until we enable custom code) and we can forget to update the version there. Since the workflow only triggers when the README changes, it will not start if we fix the version in a separate commit.

Allowing it to be triggered manually mitigates this issue.