### PR TITLE
Bumping the pyproject.toml version to 1.11.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mistralai"
-version = "1.11.0"
+version = "1.11.1"
 description = "Python Client SDK for the Mistral AI API."
 authors = [{ name = "Mistral" }]
 requires-python = ">=3.10"


### PR DESCRIPTION
This change was omitted in previous PR.