### PR TITLE
Fix JSONSchema serialization inconsistency with alias field

### DIFF
--- a/src/mistralai/client/models/jsonschema.py
+++ b/src/mistralai/client/models/jsonschema.py
@@ -42,8 +42,10 @@ class JSONSchema(BaseModel):
 
         for n, f in type(self).model_fields.items():
             k = f.alias or n
-            val = serialized.get(k)
+            # Try alias first, then field name as fallback to handle both by_alias=True and by_alias=False
+            val = serialized.get(k) or serialized.get(n)
             serialized.pop(k, None)
+            serialized.pop(n, None)
 
             optional_nullable = k in optional_fields and k in nullable_fields
             is_set = (

--- a/tests/test_jsonschema_serialization.py
+++ b/tests/test_jsonschema_serialization.py
@@ -1,0 +1,56 @@
+"""Test for JSONSchema serialization with and without by_alias parameter."""
+import json
+from mistralai.extra.utils.response_format import response_format_from_pydantic_model
+from pydantic import BaseModel, Field
+
+
+class TestModel(BaseModel):
+    name: str = Field(description="A name field")
+    value: int = Field(description="A value field")
+
+
+def test_jsonschema_serialization_without_by_alias():
+    """Test that model_dump() works without by_alias=True."""
+    response_format = response_format_from_pydantic_model(TestModel)
+
+    # This should work without by_alias=True
+    serialized = response_format.model_dump(mode='json')
+
+    # Verify that schema is not None
+    assert serialized['json_schema']['schema'] is not None, "Schema should not be None"
+
+    # Verify that schema contains expected fields
+    schema = serialized['json_schema']['schema']
+    assert 'type' in schema
+    assert 'properties' in schema
+    assert 'name' in schema['properties']
+    assert 'value' in schema['properties']
+
+
+def test_jsonschema_serialization_with_by_alias():
+    """Test that model_dump(by_alias=True) continues to work."""
+    response_format = response_format_from_pydantic_model(TestModel)
+
+    # This should work with by_alias=True
+    serialized = response_format.model_dump(mode='json', by_alias=True)
+
+    # Verify that schema is not None
+    assert serialized['json_schema']['schema'] is not None, "Schema should not be None"
+
+    # Verify that schema contains expected fields
+    schema = serialized['json_schema']['schema']
+    assert 'type' in schema
+    assert 'properties' in schema
+    assert 'name' in schema['properties']
+    assert 'value' in schema['properties']
+
+
+def test_jsonschema_serialization_consistency():
+    """Test that both serialization methods produce the same result."""
+    response_format = response_format_from_pydantic_model(TestModel)
+
+    serialized_without_alias = response_format.model_dump(mode='json')
+    serialized_with_alias = response_format.model_dump(mode='json', by_alias=True)
+
+    # Both should produce the same schema
+    assert serialized_without_alias['json_schema']['schema'] == serialized_with_alias['json_schema']['schema']


### PR DESCRIPTION
## Summary
Fixes #310 - JSONSchema serialization returns `null` for schema field when `model_dump()` is called without `by_alias=True`.

## Problem
The `JSONSchema.model_serializer` was attempting to retrieve the `schema_definition` field using its alias `"schema"`, but when `by_alias=False`, the serialized dict contains the field name `"schema_definition"` instead. This caused the schema field to be set to `None` incorrectly.

## Solution
Updated the serializer to check both the alias key and the field name when retrieving values, ensuring consistent behavior regardless of the `by_alias` parameter.

## Changes
- Modified `JSONSchema.serialize_model` to try both alias and field name when getting values
- Added comprehensive test cases to verify serialization works with and without `by_alias`
- Ensured both serialization methods produce identical results

## Test Results
```bash
$ python3 -m pytest tests/test_jsonschema_serialization.py -v
============================= test session starts ==============================
platform darwin -- Python 3.14.2, pytest-9.0.2, pluggy-1.6.0
cachedir: .pytest_cache
rootdir: /Users/vc/open source/client-python
configfile: pyproject.toml
plugins: anyio-4.12.1, mock-3.15.1, asyncio-1.3.0
collecting ... collected 3 items

tests/test_jsonschema_serialization.py::test_jsonschema_serialization_without_by_alias PASSED [ 33%]
tests/test_jsonschema_serialization.py::test_jsonschema_serialization_with_by_alias PASSED [ 66%]
tests/test_jsonschema_serialization.py::test_jsonschema_serialization_consistency PASSED [100%]

========================= 3 passed, 1 warning in 0.26s =========================
```

All existing tests continue to pass:
```bash
$ python3 -m pytest tests/ -v
============================= test session starts ==============================
platform darwin -- Python 3.14.2, pytest-9.0.2, pluggy-1.6.0
cachedir: .pytest_cache
rootdir: /Users/vc/open source/client-python
configfile: pyproject.toml
plugins: anyio-4.12.1, mock-3.15.1, asyncio-1.3.0
collecting ... collected 5 items

tests/test_jsonschema_serialization.py::test_jsonschema_serialization_without_by_alias PASSED [ 20%]
tests/test_jsonschema_serialization.py::test_jsonschema_serialization_with_by_alias PASSED [ 40%]
tests/test_jsonschema_serialization.py::test_jsonschema_serialization_consistency PASSED [ 60%]
tests/test_prepare_readme.py::test_rewrite_relative_links_keeps_absolute PASSED [ 80%]
tests/test_prepare_readme.py::test_main_prints_rewritten_readme_with_defaults PASSED [100%]

========================= 5 passed, 1 warning in 0.26s =========================
```

## Impact
This fix ensures that:
- `model_dump()` and `model_dump(by_alias=True)` produce consistent results
- Debugging and logging code that uses `model_dump()` will now see the correct schema
- No breaking changes - existing code using `by_alias=True` continues to work