### PR TITLE
PEP 420 namespace support, widen otel upper bound

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Once that is saved to a file, you can run it with `uv run script.py` where
 
 ### Agents extra dependencies
 
-When using the agents related feature it is required to add the `agents` extra dependencies. This can be added when 
+When using the agents related feature it is required to add the `agents` extra dependencies. This can be added when
 installing the package:
 
 ```bash
@@ -126,6 +126,14 @@ pip install "mistralai[agents]"
 ```
 
 > Note: These features require Python 3.10+ (the SDK minimum).
+
+### Additional packages
+
+Additional `mistralai-*` packages (e.g. `mistralai-workflows`) can be installed separately and are available under the `mistralai` namespace:
+
+```bash
+pip install mistralai-workflows
+```
 
 <!-- Start SDK Example Usage [usage] -->
 ## SDK Example Usage
@@ -410,7 +418,7 @@ gcloud auth application-default login
 Install the extras dependencies specific to Google Cloud:
 
 ```bash
-pip install mistralai[gcp]
+pip install "mistralai[gcp]"
 ```
 
 **Step 2: Example Usage**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "opentelemetry-sdk (>=1.33.1,<2.0.0)",
     "opentelemetry-api (>=1.33.1,<2.0.0)",
     "opentelemetry-exporter-otlp-proto-http (>=1.37.0,<2.0.0)",
-    "opentelemetry-semantic-conventions (>=0.59b0,<0.60)",
+    "opentelemetry-semantic-conventions (>=0.59b0,<0.61)",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- Widen `opentelemetry-semantic-conventions` upper bound from `<0.60` to `<0.61` to allow `mistralai` and `mistralai-workflows` to coexist (fixes #341)
- Add "Additional packages" section to README documenting `mistralai-*` namespace packages

## Validation

Built wheels from both repos and verified the PEP 420 namespace merge in a clean venv using the following script:

```bash
#!/usr/bin/env bash
set -euo pipefail

CLIENT_WHL="${1:?Usage: $0 <client.whl> <workflows.whl>}"
WORKFLOWS_WHL="${2:?Usage: $0 <client.whl> <workflows.whl>}"
VENV="/tmp/test-pep420-ns"
PYTHON="${PYTHON:-python3.12}"

cleanup() { rm -rf "$VENV"; }
trap cleanup EXIT

echo "=== Creating clean venv ($PYTHON) ==="
"$PYTHON" -m venv "$VENV"
source "$VENV/bin/activate"

echo ""
echo "=== Test 1: Client only ==="
pip install --quiet "$CLIENT_WHL"
python -c "from mistralai.client import Mistral; print('  client import: OK')"
python -c "
try:
    from mistralai.workflows import workflow
    print('  FAIL: workflows should not be importable')
    exit(1)
except ImportError:
    print('  workflows not importable (expected): OK')
"

echo ""
echo "=== Test 2: No __init__.py at namespace level ==="
python -c "
import pathlib, sysconfig
ns = pathlib.Path(sysconfig.get_path('purelib')) / 'mistralai' / '__init__.py'
if ns.exists():
    print('  FAIL: mistralai/__init__.py exists (breaks PEP 420)')
    exit(1)
else:
    print('  no mistralai/__init__.py: OK')
"

echo ""
echo "=== Test 3: Client + workflows ==="
pip install --quiet "$WORKFLOWS_WHL"
python -c "from mistralai.client import Mistral; print('  client import: OK')"
python -c "from mistralai.workflows import workflow; print('  workflows import: OK')"

echo ""
echo "=== Test 4: Namespace directory listing ==="
python -c "
import pathlib, sysconfig
ns = pathlib.Path(sysconfig.get_path('purelib')) / 'mistralai'
for p in sorted(ns.iterdir()):
    print(f'  {p.name}/')
"

echo ""
echo "=== All tests passed ==="
```

## Known issue: CI examples failing

The `run_example_scripts` CI job fails on fine-tuning examples (`async_jobs.py`, `jobs.py`, `dry_run_job.py`) because no models are available for completion fine-tuning on the CI API key. This is a pre-existing issue unrelated to this PR.

Builds on #340.