### PR TITLE
docs: add callout directing v1 users to v1 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Mistral Python Client
 
+> [!IMPORTANT]
+> **Looking for v1 documentation?** If you installed `mistralai` from PyPI (e.g., `pip install mistralai`), you are using **v1** of the SDK. The documentation on this branch (`main`) is for **v2**, which is not yet released on PyPI.
+>
+> **➡️ [Go to the v1 branch for v1 documentation](https://github.com/mistralai/client-python/tree/v1)**
+
 ## Migration warning
 
 This documentation is for Mistral AI SDK v2. You can find more details on how to migrate from v1 to v2 [here](MIGRATION.md)


### PR DESCRIPTION
## Summary
- Adds a prominent callout at the top of README directing users to the v1 branch
- Users installing `mistralai` from PyPI get v1, but main branch docs are for v2
- This causes confusion with import paths (e.g., `from mistralai.client import Mistral` vs `from mistralai import Mistral`)

Fixes #366

## Test plan
- [x] Verify the callout renders correctly on GitHub
- [x] Confirm the link to v1 branch works