### PR TITLE
fix: remove incorrect standalone distribution claim in migration docs

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -46,8 +46,6 @@ Azure and GCP SDKs now live under the `mistralai` namespace as separate distribu
 
 #### Installation Changes
 
-The main `mistralai` package now bundles Azure and GCP support. You can also install `mistralai-azure` or `mistralai-gcp` as standalone distributions.
-
 For GCP authentication dependencies, use `pip install "mistralai[gcp]"`.
 
 ### What Stays the Same


### PR DESCRIPTION
## Summary

Addresses review comment from #375 that was merged before being fixed.

Removes the inaccurate statement claiming that `mistralai-azure` or `mistralai-gcp` can be installed as standalone distributions - this is not supported.

## Test plan

- [x] Verified claim is removed