### PR TITLE
feat: align pyproject.toml version with gen.lock in SDK generation

### DIFF
--- a/.github/workflows/align_pyproject_version.yaml
+++ b/.github/workflows/align_pyproject_version.yaml
@@ -27,21 +27,21 @@ jobs:
       - name: Align main SDK version
         if: hashFiles('.speakeasy/gen.lock') != ''
         run: |
-          VERSION=$(grep 'releaseVersion:' .speakeasy/gen.lock | head -1 | awk '{print $2}')
+          VERSION=$(grep 'releaseVersion:' .speakeasy/gen.lock | head -1 | awk '{print $2}' | tr -d '"')
           echo "Aligning main SDK to version: $VERSION"
           uv version "$VERSION"
 
       - name: Align Azure SDK version
         if: hashFiles('packages/azure/.speakeasy/gen.lock') != ''
         run: |
-          VERSION=$(grep 'releaseVersion:' packages/azure/.speakeasy/gen.lock | head -1 | awk '{print $2}')
+          VERSION=$(grep 'releaseVersion:' packages/azure/.speakeasy/gen.lock | head -1 | awk '{print $2}' | tr -d '"')
           echo "Aligning Azure SDK to version: $VERSION"
           uv version "$VERSION" --directory packages/azure
 
       - name: Align GCP SDK version
         if: hashFiles('packages/gcp/.speakeasy/gen.lock') != ''
         run: |
-          VERSION=$(grep 'releaseVersion:' packages/gcp/.speakeasy/gen.lock | head -1 | awk '{print $2}')
+          VERSION=$(grep 'releaseVersion:' packages/gcp/.speakeasy/gen.lock | head -1 | awk '{print $2}' | tr -d '"')
           echo "Aligning GCP SDK to version: $VERSION"
           uv version "$VERSION" --directory packages/gcp
 


### PR DESCRIPTION
## Summary

Add a PR-triggered workflow that automatically aligns `pyproject.toml` version with `gen.lock` when Speakeasy generates SDK updates.

**Problem:** Speakeasy updates `gen.lock` with the new `releaseVersion`, but `pyproject.toml` is in `.genignore` so Speakeasy cannot update it. This causes version mismatch.

**Solution:** A separate workflow that:
- Triggers on PR events when `gen.lock` files change
- Only runs for PRs from `speakeasybot`
- Reads `releaseVersion` from `gen.lock`
- Updates `pyproject.toml` using `uv version`
- Commits and pushes the change

## Test plan

1. Merge this PR
2. Trigger a Speakeasy generation (e.g., "Generate MISTRALAI" workflow)
3. Verify the resulting PR has an additional commit aligning the version