### PR TITLE
fix: check for github-actions[bot] in align workflow

### DIFF
--- a/.github/workflows/align_pyproject_version.yaml
+++ b/.github/workflows/align_pyproject_version.yaml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   align-version:
-    if: github.actor == 'speakeasybot'
+    if: github.actor == 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch


### PR DESCRIPTION
## Summary

Fix the align pyproject.toml workflow to trigger on PRs from `github-actions[bot]` instead of `speakeasybot`.

Speakeasy SDK generation PRs are authored by `github-actions[bot]`, not `speakeasybot`, so the workflow was never running.

## Test plan

- Verify PR #386 triggers the workflow after this is merged