### PR TITLE
fix: check PR author instead of actor in align workflow

### DIFF
--- a/.github/workflows/align_pyproject_version.yaml
+++ b/.github/workflows/align_pyproject_version.yaml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   align-version:
-    if: github.actor == 'github-actions[bot]'
+    if: github.event.pull_request.user.login == 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch


### PR DESCRIPTION
## Summary

Fix the align workflow condition to check the PR author (`github.event.pull_request.user.login`) instead of the actor (`github.actor`).

**Problem:** `github.actor` is who triggered the event (pushed the commit), not the PR author. When anyone pushes to a Speakeasy PR, the workflow skips because the actor isn't `github-actions[bot]`.

**Solution:** Use `github.event.pull_request.user.login` which correctly identifies the PR author.

## Test plan

1. Merge this PR
2. Push to PR #386 to trigger the workflow
3. Verify the workflow runs and updates pyproject.toml