### PR TITLE
chore: target v1 registry tag instead of main

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -3,13 +3,13 @@ speakeasyVersion: 1.685.0
 sources:
     mistral-azure-source:
         inputs:
-        -   location: registry.speakeasyapi.dev/mistral-dev/mistral-dev/mistral-openapi-azure:main
+        -   location: registry.speakeasyapi.dev/mistral-dev/mistral-dev/mistral-openapi-azure:v1
     mistral-google-cloud-source:
         inputs:
-        -   location: registry.speakeasyapi.dev/mistral-dev/mistral-dev/mistral-openapi-google-cloud:main
+        -   location: registry.speakeasyapi.dev/mistral-dev/mistral-dev/mistral-openapi-google-cloud:v1
     mistral-openapi:
         inputs:
-        -   location: registry.speakeasyapi.dev/mistral-dev/mistral-dev/mistral-openapi:main
+        -   location: registry.speakeasyapi.dev/mistral-dev/mistral-dev/mistral-openapi:v1
 targets:
     mistralai-azure-sdk:
         target: python


### PR DESCRIPTION
## Summary
- Pin all three OpenAPI source registries to the `v1` tag instead of `main` in `.speakeasy/workflow.yaml`
- Safer now that we have two versions to support, avoiding unintended v2 changes from `main`

## Test plan
- [x] Verify Speakeasy generation still works with the `v1` tag