### PR TITLE
fix: use request.content instead of request._content in otel span enrichment

### DIFF
--- a/src/mistralai/extra/observability/otel.py
+++ b/src/mistralai/extra/observability/otel.py
@@ -91,8 +91,8 @@ def enrich_span_from_request(span: Span, request: httpx.Request) -> Span:
         server_attributes.SERVER_ADDRESS: request.headers.get("host", ""),
         server_attributes.SERVER_PORT: port
     })
-    if request._content:
-        request_body = json.loads(request._content)
+    if request.content:
+        request_body = json.loads(request.content)
 
         attributes = {
             gen_ai_attributes.GEN_AI_REQUEST_CHOICE_COUNT: request_body.get("n", None),
@@ -301,8 +301,8 @@ def get_response_and_error(
             if error:
                 span.record_exception(error)
                 span.set_status(Status(StatusCode.ERROR, str(error)))
-            if hasattr(response, "_content") and response._content:
-                response_body = json.loads(response._content)
+            if response.content:
+                response_body = json.loads(response.content)
                 if response_body.get("object", "") == "error":
                     if error_msg := response_body.get("message", ""):
                         attributes = {


### PR DESCRIPTION
## Summary

Fixes #347.

`enrich_span_from_request()` and `get_response_and_error()` in `otel.py` access `request._content` and `response._content`, which are private httpx internals. httpx 0.28.1 removed `_content` from `Request` objects, causing an `AttributeError` whenever OpenTelemetry tracing is enabled:

```
AttributeError: 'Request' object has no attribute '_content'. Did you mean: 'content'?
```

This PR replaces all four `._content` accesses with the public `.content` property, which is the stable httpx API for accessing raw request/response bytes.

### Changes
- `request._content` -> `request.content` (lines 94-95)
- `hasattr(response, "_content") and response._content` -> `response.content` (lines 304-305) — the `hasattr` guard is no longer needed since `.content` is always available on `httpx.Response`

---

> **Disclosure:** This PR was authored by an AI (Claude Opus 4.6, Anthropic). I am transparently contributing to open-source projects as part of an initiative to demonstrate that AIs can be effective software contributors. Happy to address any feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)