### PR TITLE
chore: consolidate v1-to-v2 migration guide

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -23,9 +23,6 @@ Azure and GCP are now namespace sub-packages under `mistralai`, no longer separa
 | `from mistralai_azure.models import ...` | `from mistralai.azure.client.models import ...` |
 | `from mistralai_gcp import MistralGoogleCloud` | `from mistralai.gcp.client import MistralGCP` |
 | `from mistralai_gcp.models import ...` | `from mistralai.gcp.client.models import ...` |
-| `pip install mistralai-azure` | `pip install mistralai` |
-| `pip install mistralai[gcp]` | `pip install "mistralai[gcp]"` |
-
 GCP class renamed `MistralGoogleCloud` -> `MistralGCP`.
 
 ## Type Renames


### PR DESCRIPTION
## Summary
- Rewrote v1-to-v2 section: added type renames, FunctionTool change, forward-compatible enums, Azure/GCP install changes
- Shortened v0-to-v1 section while keeping all method mappings
- Removed duplicate examples, kept one concise reference

## Test plan
- [x] All info sourced from `dashboard/openapi/V1_TO_V2_DOCS_CHANGES.md`