### PR TITLE
Update import statements for Mistral module

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ It's also possible to write a standalone Python script without needing to set up
 # ]
 # ///
 
-from mistralai.client import Mistral
+from mistralai import Mistral
 
 sdk = Mistral(
   # SDK arguments
@@ -149,7 +149,7 @@ This example shows how to create chat completions.
 
 ```python
 # Synchronous Example
-from mistralai.client import Mistral
+from mistralai import Mistral
 import os
 
 
@@ -177,7 +177,7 @@ The same SDK client can also be used to make asynchronous requests by importing 
 ```python
 # Asynchronous Example
 import asyncio
-from mistralai.client import Mistral
+from mistralai import Mistral
 import os
 
 async def main():
@@ -207,7 +207,7 @@ This example shows how to upload a file.
 
 ```python
 # Synchronous Example
-from mistralai.client import Mistral
+from mistralai import Mistral
 import os
 
 
@@ -231,7 +231,7 @@ The same SDK client can also be used to make asynchronous requests by importing 
 ```python
 # Asynchronous Example
 import asyncio
-from mistralai.client import Mistral
+from mistralai import Mistral
 import os
 
 async def main():
@@ -257,7 +257,7 @@ This example shows how to create agents completions.
 
 ```python
 # Synchronous Example
-from mistralai.client import Mistral
+from mistralai import Mistral
 import os
 
 
@@ -285,7 +285,7 @@ The same SDK client can also be used to make asynchronous requests by importing 
 ```python
 # Asynchronous Example
 import asyncio
-from mistralai.client import Mistral
+from mistralai import Mistral
 import os
 
 async def main():
@@ -315,7 +315,7 @@ This example shows how to create embedding request.
 
 ```python
 # Synchronous Example
-from mistralai.client import Mistral
+from mistralai import Mistral
 import os
 
 
@@ -339,7 +339,7 @@ The same SDK client can also be used to make asynchronous requests by importing 
 ```python
 # Asynchronous Example
 import asyncio
-from mistralai.client import Mistral
+from mistralai import Mistral
 import os
 
 async def main():
@@ -673,7 +673,7 @@ The stream is also a [Context Manager][context-manager] and can be used with the
 underlying connection when the context is exited.
 
 ```python
-from mistralai.client import Mistral
+from mistralai import Mistral
 import os
 
 
@@ -717,7 +717,7 @@ Certain SDK methods accept file objects as part of a request body or multi-part 
 >
 
 ```python
-from mistralai.client import Mistral
+from mistralai import Mistral
 import os
 
 
@@ -743,7 +743,7 @@ Some of the endpoints in this SDK support retries. If you use the SDK without an
 
 To change the default retry strategy for a single API call, simply provide a `RetryConfig` object to the call:
 ```python
-from mistralai.client import Mistral
+from mistralai import Mistral
 from mistralai.client.utils import BackoffStrategy, RetryConfig
 import os
 
@@ -762,7 +762,7 @@ with Mistral(
 
 If you'd like to override the default retry strategy for all operations that support retries, you can use the `retry_config` optional parameter when initializing the SDK:
 ```python
-from mistralai.client import Mistral
+from mistralai import Mistral
 from mistralai.client.utils import BackoffStrategy, RetryConfig
 import os
 
@@ -796,7 +796,7 @@ with Mistral(
 
 ### Example
 ```python
-from mistralai.client import Mistral, errors
+from mistralai import Mistral, errors
 import os
 
 
@@ -863,7 +863,7 @@ You can override the default server globally by passing a server name to the `se
 #### Example
 
 ```python
-from mistralai.client import Mistral
+from mistralai import Mistral
 import os
 
 
@@ -883,7 +883,7 @@ with Mistral(
 
 The default server can also be overridden globally by passing a URL to the `server_url: str` optional parameter when initializing the SDK client instance. For example:
 ```python
-from mistralai.client import Mistral
+from mistralai import Mistral
 import os
 
 
@@ -909,7 +909,7 @@ This allows you to wrap the client with your own custom logic, such as adding cu
 
 For example, you could specify a header for every request that this sdk makes as follows:
 ```python
-from mistralai.client import Mistral
+from mistralai import Mistral
 import httpx
 
 http_client = httpx.Client(headers={"x-custom-header": "someValue"})
@@ -918,7 +918,7 @@ s = Mistral(client=http_client)
 
 or you could wrap the client with your own custom logic:
 ```python
-from mistralai.client import Mistral
+from mistralai import Mistral
 from mistralai.client.httpclient import AsyncHttpClient
 import httpx
 
@@ -994,7 +994,7 @@ This SDK supports the following security scheme globally:
 
 To authenticate with the API the `api_key` parameter must be set when initializing the SDK client instance. For example:
 ```python
-from mistralai.client import Mistral
+from mistralai import Mistral
 import os
 
 
@@ -1018,7 +1018,7 @@ The `Mistral` class implements the context manager protocol and registers a fina
 [context-manager]: https://docs.python.org/3/reference/datamodel.html#context-managers
 
 ```python
-from mistralai.client import Mistral
+from mistralai import Mistral
 import os
 def main():
 
@@ -1045,7 +1045,7 @@ You can setup your SDK to emit debug logs for SDK requests and responses.
 
 You can pass your own logger class directly into your SDK.
 ```python
-from mistralai.client import Mistral
+from mistralai import Mistral
 import logging
 
 logging.basicConfig(level=logging.DEBUG)


### PR DESCRIPTION
After testing the sdk, it seems the imports from the documentation are not up to date.

Getting following error: ImportError: cannot import name 'Mistral' from 'mistralai.client' (/lib/python3.12/site-packages/mistralai/client.py)