### PR TITLE
ci: publish v2 from main

### DIFF
--- a/.github/workflows/sdk_publish_mistralai_sdk.yaml
+++ b/.github/workflows/sdk_publish_mistralai_sdk.yaml
@@ -6,23 +6,15 @@ permissions:
   statuses: write
 "on":
   workflow_dispatch:
-    inputs:
-      confirm_publish:
-        description: 'WARNING: This will publish v2 SDK (mistralai.client namespace) which is still WIP/alpha. To publish v1 (mistralai namespace), use the v1 branch instead. Type "publish" to confirm.'
-        required: false
-        type: string
   push:
     branches:
-      - v1
+      - main
     paths:
       - RELEASES.md
       - "*/RELEASES.md"
 jobs:
   publish:
-    # Auto-publish from v1 branch; require manual confirmation from main
-    if: |
-      github.ref == 'refs/heads/v1' ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.confirm_publish == 'publish')
+    if: github.ref == 'refs/heads/main'
     uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@7951d9dce457425b900b2dd317253499d98c2587 # v15
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- switch the publish workflow trigger from `v1` to `main`
- remove the manual `confirm_publish` input and warning text for v2
- keep publish limited to runs on the `main` ref