### PR TITLE
feat: use compileCommands with pylint -j=1 to prevent OOM

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -79,6 +79,13 @@ python:
   moduleName: mistralai.client
   multipartArrayFormat: standard
   outputModelSuffix: output
+  compileCommands:
+    - ["uv", "lock"]
+    - ["uv", "sync", "--dev"]
+    - ["uv", "run", "python", "-m", "compileall", "-q", "."]
+    - ["uv", "run", "python", "-m", "pylint", "-j=1", "src/mistralai"]
+    - ["uv", "run", "python", "-m", "mypy", "src/mistralai"]
+    - ["uv", "run", "python", "-m", "pyright", "src/mistralai"]
   packageManager: uv
   packageName: mistralai
   preApplyUnionDiscriminators: true


### PR DESCRIPTION
## Summary
- Adds `compileCommands` to `.speakeasy/gen.yaml` to override the default Python compilation pipeline
- Sets `pylint -j=1` (single process) instead of the default `-j=0` (auto-detect parallelism) to prevent out-of-memory errors during SDK generation
- Preserves all other compilation steps (uv lock, uv sync, compileall, mypy, pyright)

## Context
The default Python compilation pipeline uses `pylint -j=0`, which auto-detects the number of CPU cores and spawns that many parallel processes. In CI environments with limited memory, this can cause OOM failures. The new `compileCommands` feature (Speakeasy CLI v1.756.0) allows overriding this behavior.

## Test plan
- [ ] Run `speakeasy run --force` to verify the custom compile commands execute correctly
- [ ] Verify pylint runs with `-j=1` and does not OOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)