### PR TITLE
Fix Azure OCR base URL normalization for Foundry target URIs

### DIFF
--- a/packages/azure/src/mistralai/azure/client/_hooks/registration.py
+++ b/packages/azure/src/mistralai/azure/client/_hooks/registration.py
@@ -1,4 +1,10 @@
-from .types import Hooks
+from __future__ import annotations
+
+from urllib.parse import urlsplit, urlunsplit
+
+from mistralai.azure.client.httpclient import HttpClient
+
+from .types import Hooks, SDKInitHook
 
 
 # This file is only ever generated once on the first generation and then is free to be modified.
@@ -6,7 +12,36 @@ from .types import Hooks
 # in this file or in separate files in the hooks folder.
 
 
+def _normalize_azure_base_url(base_url: str) -> str:
+    """
+    Users frequently copy operation-scoped "Target URI" values from Azure AI Foundry,
+    e.g. endpoints ending in `/ocr` or `/chat/completions`.
+
+    The generated SDK operations append their own paths (OCR uses path="/ocr", chat uses
+    path="/chat/completions"), so if the base_url already ends with those suffixes the
+    resulting URL becomes duplicated (e.g. .../ocr/ocr) and fails.
+    """
+
+    parts = urlsplit(base_url)
+    path = parts.path.rstrip("/")
+
+    known_suffixes = ("/ocr", "/chat/completions")
+    for suffix in known_suffixes:
+        if path.endswith(suffix):
+            path = path[: -len(suffix)].rstrip("/")
+            break
+
+    return urlunsplit((parts.scheme, parts.netloc, path, parts.query, parts.fragment))
+
+
+class _NormalizeBaseUrlHook(SDKInitHook):
+    def sdk_init(self, base_url: str, client: HttpClient):
+        return _normalize_azure_base_url(base_url), client
+
+
 def init_hooks(_hooks: Hooks) -> None:
     """Add hooks by calling hooks.register{sdk_init/before_request/after_success/after_error}Hook
     with an instance of a hook that implements that specific Hook interface
     Hooks are registered per SDK instance, and are valid for the lifetime of the SDK instance"""
+
+    _hooks.register_sdk_init_hook(_NormalizeBaseUrlHook())

--- a/tests/test_azure_endpoint_normalization.py
+++ b/tests/test_azure_endpoint_normalization.py
@@ -1,0 +1,45 @@
+import httpx
+
+
+def test_azure_ocr_endpoint_strips_trailing_ocr_suffix():
+    """
+    If users copy the full OCR target URI from Azure AI Foundry (ending in /ocr),
+    the SDK should not call /ocr/ocr.
+    """
+    from mistralai.azure.client import MistralAzure
+
+    seen_urls: list[str] = []
+
+    def on_request(request: httpx.Request) -> None:
+        seen_urls.append(str(request.url))
+
+    client = httpx.Client(
+        params={"api-version": "2024-05-01-preview"},
+        event_hooks={"request": [on_request]},
+    )
+
+    sdk = MistralAzure(
+        api_key="dummy",
+        server_url="https://example.com/providers/mistral/azure/ocr",
+        client=client,
+    )
+
+    # Force request building; it will fail to connect, but the hook captures the URL.
+    try:
+        sdk.ocr.process(
+            model="mistral-document-ai-2505",
+            document={
+                "type": "document_url",
+                "document_url": "data:application/pdf;base64,AA==",
+            },
+            include_image_base64=False,
+        )
+    except Exception:
+        pass
+
+    assert seen_urls, "expected at least one outgoing request"
+    assert "/ocr/ocr" not in seen_urls[0]
+    assert seen_urls[0].startswith(
+        "https://example.com/providers/mistral/azure/ocr?"
+    ), seen_urls[0]
+


### PR DESCRIPTION
## Summary

Closes #292 

Fix Azure OCR calls when users paste the full Azure AI Foundry “Target URI” (ending in `/ocr`) as `server_url`.  
Previously the SDK appended `/ocr` again (because `Ocr.process()` uses `path="/ocr"`), producing `.../ocr/ocr` and a 404.

This change normalizes the configured base URL at SDK init time by stripping well-known operation suffixes:
- `/ocr`
- `/chat/completions`

## Changes

- Add an SDK init hook in `packages/azure/src/mistralai/azure/client/_hooks/registration.py` to normalize `server_url` by stripping the suffixes above.
- Add a unit test `tests/test_azure_endpoint_normalization.py` asserting the outgoing OCR request URL does **not** contain `"/ocr/ocr"` when `server_url` ends with `/ocr`.

## Repro (before)

Using `server_url=https://<resource>.services.ai.azure.com/providers/mistral/azure/ocr`:

- SDK sends: `.../providers/mistral/azure/ocr/ocr?api-version=...` → 404

## Repro (after)

Using the same `server_url` ending in `/ocr`:

- SDK sends: `.../providers/mistral/azure/ocr?api-version=...` (single `/ocr`) → succeeds

## Test plan

- [x] `pytest -q tests/test_azure_endpoint_normalization.py`
- [x] (Optional, requires creds) run OCR call against Foundry with `server_url` ending in `/ocr` and confirm it succeeds.


