### PR TITLE
fix(client): respect httpx client-level timeout when timeout_ms is None

### DIFF
--- a/src/mistralai/client/basesdk.py
+++ b/src/mistralai/client/basesdk.py
@@ -216,17 +216,22 @@ class BaseSDK:
             for header, value in http_headers.items():
                 headers[header] = value
 
-        timeout = timeout_ms / 1000 if timeout_ms is not None else None
+        # Build request kwargs, only include timeout if explicitly set
+        # to respect httpx client-level timeout when timeout_ms is None
+        kwargs: dict = {
+            "params": query_params,
+            "content": serialized_request_body.content,
+            "data": serialized_request_body.data,
+            "files": serialized_request_body.files,
+            "headers": headers,
+        }
+        if timeout_ms is not None:
+            kwargs["timeout"] = timeout_ms / 1000
 
         return client.build_request(
             method,
             url,
-            params=query_params,
-            content=serialized_request_body.content,
-            data=serialized_request_body.data,
-            files=serialized_request_body.files,
-            headers=headers,
-            timeout=timeout,
+            **kwargs,
         )
 
     def do_request(


### PR DESCRIPTION
## Summary

The SDK was passing `timeout=None` to httpx's `build_request()` when `timeout_ms` was not specified, which **disables all timeouts** instead of falling back to the client's configured timeout.

## Problem

When users configure a custom httpx client with timeouts:

```python
import httpx
from mistralai.client import Mistral

async_client = httpx.AsyncClient(
    timeout=httpx.Timeout(None, connect=10.0, read=30.0),
)
client = Mistral(api_key="...", async_client=async_client)
```

The SDK overrides this by passing `timeout=None` to `build_request()`, causing requests to **hang indefinitely** when the server fails to respond (e.g., `tool_choice="required"` with certain models).

## Root Cause

In httpx, `timeout=None` means **no timeout at all**, not "use client default". Only `USE_CLIENT_DEFAULT` triggers the fallback to `self.timeout`.

```python
# httpx behavior:
client.build_request(url, timeout=None)  # Disables timeout!
client.build_request(url)  # Uses client's timeout (USE_CLIENT_DEFAULT)
```

## Fix

Only include `timeout` in kwargs when explicitly set:

```python
kwargs = {...}
if timeout_ms is not None:
    kwargs["timeout"] = timeout_ms / 1000
return client.build_request(method, url, **kwargs)
```

Fixes #449