### PR TITLE
chore: align pyproject.toml and uv.lock to version 2.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mistralai"
-version = "2.2.0rc3"
+version = "2.2.0"
 description = "Python Client SDK for the Mistral AI API."
 authors = [{ name = "Mistral" }]
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -560,7 +560,7 @@ wheels = [
 
 [[package]]
 name = "mistralai"
-version = "2.2.0rc3"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "eval-type-backport" },


### PR DESCRIPTION
This step was run manually because there are no Speakeasy differences with v2.2.0rc3, so running the `Generate MISTRALAI` workflow does not generate a PR.

The only addition is the registration hook `src/mistralai/client/_hooks/traceparent.py`.