### PR TITLE
fix: remove typehint causing ci error

### DIFF
--- a/examples/mistral/chat/function_calling.py
+++ b/examples/mistral/chat/function_calling.py
@@ -95,6 +95,7 @@ messages: list[ChatCompletionRequestMessage] = [
 
 response = client.chat.complete(model=model, messages=messages, tools=tools, temperature=0)
 
+assert response.choices[0].message is not None
 print(response.choices[0].message.content)
 
 messages.append(AssistantMessage(content=response.choices[0].message.content))
@@ -102,6 +103,7 @@ messages.append(UserMessage(content="My transaction ID is T1001."))
 
 response = client.chat.complete(model=model, messages=messages, tools=tools, temperature=0)
 
+assert response.choices[0].message is not None
 tool_calls = response.choices[0].message.tool_calls
 if not tool_calls:
     raise RuntimeError("Expected tool calls")
@@ -130,4 +132,5 @@ print(messages)
 
 response = client.chat.complete(model=model, messages=messages, tools=tools, temperature=0)
 
+assert response.choices[0].message is not None
 print(f"{response.choices[0].message.content}")

--- a/src/mistralai/client/conversations.py
+++ b/src/mistralai/client/conversations.py
@@ -98,7 +98,7 @@ class Conversations(BaseSDK):
         from mistralai.extra.run.tools import get_function_calls  # pylint: disable=import-outside-toplevel
 
         # Check if inputs contain deferred responses - process them
-        pending_tool_confirmations: Optional[List[models.ToolCallConfirmation]] = None
+        pending_tool_confirmations = None
         if inputs and isinstance(inputs, list):
             deferred_inputs = typing.cast(
                 List[DeferredToolCallResponse],
@@ -240,7 +240,7 @@ class Conversations(BaseSDK):
         from mistralai.extra.run.tools import get_function_calls  # pylint: disable=import-outside-toplevel
 
         # Check if inputs contain deferred responses - process them
-        pending_tool_confirmations: Optional[List[models.ToolCallConfirmation]] = None
+        pending_tool_confirmations = None
         if inputs and isinstance(inputs, list):
             deferred_inputs = typing.cast(
                 List[DeferredToolCallResponse],


### PR DESCRIPTION
mypy treats the tuple unpacking of `_process_deferred_responses` as a redefinition when the variable is explicitly annotated above and causes ci to fail