### PR TITLE
fix(conversations): dedupe deferred-responses block in run_async

### DIFF
--- a/src/mistralai/client/conversations.py
+++ b/src/mistralai/client/conversations.py
@@ -116,25 +116,6 @@ class Conversations(BaseSDK):
                 if not pending_tool_confirmations:
                     pending_tool_confirmations = None
 
-        # Check if inputs contain deferred responses - process them
-        pending_tool_confirmations = None
-        if inputs and isinstance(inputs, list):
-            deferred_inputs = typing.cast(
-                List[DeferredToolCallResponse],
-                [i for i in inputs if _is_deferred_response(i)],
-            )
-            other_inputs = typing.cast(
-                List[InputEntries], [i for i in inputs if not _is_deferred_response(i)]
-            )
-            if deferred_inputs:
-                (
-                    processed,
-                    pending_tool_confirmations,
-                ) = await _process_deferred_responses(run_ctx, deferred_inputs)
-                inputs = other_inputs + processed
-                if not pending_tool_confirmations:
-                    pending_tool_confirmations = None
-
         with tracer.start_as_current_span(GenAISpanEnum.VALIDATE_RUN.value):
             req, run_result, input_entries = await _validate_run(
                 beta_client=Beta(self.sdk_configuration),


### PR DESCRIPTION
## Summary
- Removes a duplicate copy of the deferred-response handling block inside `Conversations.run_async` in `src/mistralai/client/conversations.py`. The Speakeasy regen in #484 re-emitted the block (originally hand-added inside the `sdk-class-body` custom region in #482) on top of the existing one, leaving two identical copies.
- The second copy unconditionally reset `pending_tool_confirmations = None`, silently dropping the server-side HITL confirmations the first block had just computed. Deleting the duplicate restores correct behavior.

## Notes
- The duplicate `nonlocal pending_tool_confirmations` previously reported in `run_stream_async` is no longer present on `main` and did not need a fix here.
- Per Speakeasy's analysis, the root cause is on their side (a ruff-formatting drift that confuses diffmatchpatch's overlap detector during region merge). They are tracking a longer-term fix; this PR is the manual cleanup on our side.