### PR TITLE
Bump SDK to v2.4.4 in pyproject.toml only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mistralai"
-version = "2.4.3"
+version = "2.4.4"
 description = "Python Client SDK for the Mistral AI API."
 authors = [{ name = "Mistral" }]
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1015,7 +1015,7 @@ wheels = [
 
 [[package]]
 name = "mistralai"
-version = "2.4.3"
+version = "2.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "eval-type-backport" },


### PR DESCRIPTION
This was meant to happen in
https://github.com/mistralai/client-python/pull/506 but it was somehow missed. So we are manually bumping the version.