### PR TITLE
ci: use deterministic generated branch for version alignment

### DIFF
--- a/.github/workflows/sdk_generation_mistralai_azure_sdk.yaml
+++ b/.github/workflows/sdk_generation_mistralai_azure_sdk.yaml
@@ -44,6 +44,7 @@ jobs:
       set_version: ${{ github.event.inputs.set_version }}
       speakeasy_version: ${{ needs.resolve-speakeasy-version.outputs.version }}
       target: mistralai-azure-sdk
+      feature_branch: speakeasy-sdk-regen-${{ github.run_id }}
     secrets:
       github_access_token: ${{ secrets.CLIENT_PIPELINE }}
       pypi_token: ${{ secrets.PYPI_TOKEN }}
@@ -57,10 +58,12 @@ jobs:
         id: find-pr
         env:
           GH_TOKEN: ${{ secrets.CLIENT_PIPELINE }}
+          SPEAKEASY_BRANCH: speakeasy-sdk-regen-${{ github.run_id }}
         run: |
-          PR_BRANCH=$(gh pr list --repo ${{ github.repository }} --author "app/github-actions" \
-            --json headRefName,updatedAt --jq 'sort_by(.updatedAt) | reverse | .[0].headRefName // empty')
-          echo "branch=$PR_BRANCH" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          PR_BRANCH="$SPEAKEASY_BRANCH"
+          echo "Using Speakeasy generated branch: $PR_BRANCH"
+          echo "branch=$PR_BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: Checkout PR branch
         if: steps.find-pr.outputs.branch != ''

--- a/.github/workflows/sdk_generation_mistralai_gcp_sdk.yaml
+++ b/.github/workflows/sdk_generation_mistralai_gcp_sdk.yaml
@@ -44,6 +44,7 @@ jobs:
       set_version: ${{ github.event.inputs.set_version }}
       speakeasy_version: ${{ needs.resolve-speakeasy-version.outputs.version }}
       target: mistralai-gcp-sdk
+      feature_branch: speakeasy-sdk-regen-${{ github.run_id }}
     secrets:
       github_access_token: ${{ secrets.CLIENT_PIPELINE }}
       pypi_token: ${{ secrets.PYPI_TOKEN }}
@@ -57,10 +58,12 @@ jobs:
         id: find-pr
         env:
           GH_TOKEN: ${{ secrets.CLIENT_PIPELINE }}
+          SPEAKEASY_BRANCH: speakeasy-sdk-regen-${{ github.run_id }}
         run: |
-          PR_BRANCH=$(gh pr list --repo ${{ github.repository }} --author "app/github-actions" \
-            --json headRefName,updatedAt --jq 'sort_by(.updatedAt) | reverse | .[0].headRefName // empty')
-          echo "branch=$PR_BRANCH" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          PR_BRANCH="$SPEAKEASY_BRANCH"
+          echo "Using Speakeasy generated branch: $PR_BRANCH"
+          echo "branch=$PR_BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: Checkout PR branch
         if: steps.find-pr.outputs.branch != ''

--- a/.github/workflows/sdk_generation_mistralai_sdk.yaml
+++ b/.github/workflows/sdk_generation_mistralai_sdk.yaml
@@ -44,6 +44,7 @@ jobs:
       set_version: ${{ github.event.inputs.set_version }}
       speakeasy_version: ${{ needs.resolve-speakeasy-version.outputs.version }}
       target: mistralai-sdk
+      feature_branch: speakeasy-sdk-regen-${{ github.run_id }}
     secrets:
       github_access_token: ${{ secrets.CLIENT_PIPELINE }}
       pypi_token: ${{ secrets.PYPI_TOKEN }}
@@ -57,10 +58,12 @@ jobs:
         id: find-pr
         env:
           GH_TOKEN: ${{ secrets.CLIENT_PIPELINE }}
+          SPEAKEASY_BRANCH: speakeasy-sdk-regen-${{ github.run_id }}
         run: |
-          PR_BRANCH=$(gh pr list --repo ${{ github.repository }} --author "app/github-actions" \
-            --json headRefName,updatedAt --jq 'sort_by(.updatedAt) | reverse | .[0].headRefName // empty')
-          echo "branch=$PR_BRANCH" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          PR_BRANCH="$SPEAKEASY_BRANCH"
+          echo "Using Speakeasy generated branch: $PR_BRANCH"
+          echo "branch=$PR_BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: Checkout PR branch
         if: steps.find-pr.outputs.branch != ''


### PR DESCRIPTION
Fixes the SDK generation workflows so post-generation version alignment checks out the branch generated by the same workflow run, instead of searching for the latest PR by author.

Why:
- Generated PR authors can vary, so `gh pr list --author app/github-actions` can miss the PR.
- The pinned Speakeasy reusable workflow accepts a `feature_branch` input, so we set a deterministic per-run branch name with `github.run_id` and reuse the same value in the alignment job.
- Existing token plumbing is unchanged: `GH_TOKEN` and checkout still use `secrets.CLIENT_PIPELINE`.

Updated workflows:
- `.github/workflows/sdk_generation_mistralai_sdk.yaml`
- `.github/workflows/sdk_generation_mistralai_azure_sdk.yaml`
- `.github/workflows/sdk_generation_mistralai_gcp_sdk.yaml`

Validation:
- `git diff --check`
- YAML parse for all three changed workflows
- Confirmed the pinned Speakeasy reusable workflow accepts `feature_branch`
- Manually dispatched the workflow from this branch and confirmed the deterministic generated branch flow works end to end
