### PR TITLE
chore: 🐝 Update SDK - Generate MISTRALAI MISTRALAI-SDK [speakeasy-sdk-regen-25657723146] 2.4.6

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,15 +5,15 @@ management:
   docVersion: 1.0.0
   speakeasyVersion: 1.761.1
   generationVersion: 2.879.6
-  releaseVersion: 2.4.5
-  configChecksum: f6852fb59e3bcc9a7750210521f2c2d4
+  releaseVersion: 2.4.6
+  configChecksum: 49adf68e99fa9f97295f7d2573756c6b
   repoURL: https://github.com/mistralai/client-python.git
   installationURL: https://github.com/mistralai/client-python.git
   published: true
 persistentEdits:
-  generation_id: bcab0c88-1877-4209-a77d-49b4681f030e
-  pristine_commit_hash: 56d30233849b5a3cb3d207e646ee849c77835f70
-  pristine_tree_hash: 3feb3429dfead0d0228262509f23a6c5e9c9c7a2
+  generation_id: 69ae9488-003b-4e00-aec6-df7bf14ee113
+  pristine_commit_hash: fba3a48c7646098340a73b0e5c20dffbb8d023a7
+  pristine_tree_hash: db3439e8c42d4b3d2e613c3e58531733ec6fe8df
 features:
   python:
     acceptHeaders: 3.0.0
@@ -3348,8 +3348,8 @@ trackedFiles:
     pristine_git_object: 036d44b8cfc51599873bd5c401a6aed30450536c
   src/mistralai/client/_version.py:
     id: cc807b30de19
-    last_write_checksum: sha1:6b2772cd63b60cddf4ea95d94cfc44f81a878a73
-    pristine_git_object: 9f9ae8c6224af17b3e22410b33f5a5ad37389e33
+    last_write_checksum: sha1:b60d9f81024f0a37e4137751a7e7e9e323f2b9b8
+    pristine_git_object: d4969426e57c58605d8874bcb7418d7eecdd9dd7
   src/mistralai/client/accesses.py:
     id: 76fc53bfcf59
     last_write_checksum: sha1:de197fbbfea8bc95f44b4e7ee1b39e68fdde8bc7
@@ -8716,14 +8716,6 @@ examples:
           application/json: {}
 examplesVersion: 1.0.2
 generatedTests: {}
-releaseNotes: |
-  ## Python SDK Changes:
-  * `mistral.workflows.executions.stream()`:  `response.[].data.data.union(CustomTaskInProgressResponse).attributes.payload` **Changed** (Breaking ⚠️)
-  * `mistral.workflows.events.get_stream_events()`:  `response.[].data.data` **Changed** (Breaking ⚠️)
-  * `mistral.workflows.events.get_workflow_events()`:  `response.events[]` **Changed** (Breaking ⚠️)
-  * `mistral.events.get_stream_events()`:  `response.[].data.data.union(CustomTaskInProgressResponse).attributes.payload` **Changed** (Breaking ⚠️)
-  * `mistral.events.get_workflow_events()`:  `response.events[]` **Changed** (Breaking ⚠️)
-  * `mistral.beta.connectors.get_authentication_methods()`:  `response.[].has_default_credentials` **Added**
 generatedFiles:
   - .gitattributes
   - .vscode/settings.json

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -32,7 +32,7 @@ generation:
     generateNewTests: false
     skipResponseBodyAssertions: false
 python:
-  version: 2.4.5
+  version: 2.4.6
   additionalDependencies:
     dev:
       pytest: ^8.2.2

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -41,7 +41,7 @@ targets:
         sourceRevisionDigest: sha256:6b325264f8e8a60caa875776438b07d4eb5b56283da0796b283e9c5597810e22
         sourceBlobDigest: sha256:11d21b003c903f5539d5d7a79cf8fe17d1d284b48e47da0009eac3866ad58899
         codeSamplesNamespace: mistral-openapi-code-samples
-        codeSamplesRevisionDigest: sha256:95c443855a95966259bd108beec0cbdb8238f6f753dc4b021bf833d398e86c0c
+        codeSamplesRevisionDigest: sha256:a5d1bd3c9b8821767ebf9e600dd03c9f27a6994d555ed72ca1088cfa9aa58b0b
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: 1.761.1

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -639,3 +639,13 @@ Based on:
 - [python v2.4.5] .
 ### Releases
 - [PyPI v2.4.5] https://pypi.org/project/mistralai/2.4.5 - .
+
+## 2026-05-11 07:59:46
+### Changes
+Based on:
+- OpenAPI Doc  
+- Speakeasy CLI 1.761.1 (2.879.6) https://github.com/speakeasy-api/speakeasy
+### Generated
+- [python v2.4.6] .
+### Releases
+- [PyPI v2.4.6] https://pypi.org/project/mistralai/2.4.6 - .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mistralai"
-version = "2.4.5"
+version = "2.4.6"
 description = "Python Client SDK for the Mistral AI API."
 authors = [{ name = "Mistral" }]
 requires-python = ">=3.10"

--- a/src/mistralai/client/_version.py
+++ b/src/mistralai/client/_version.py
@@ -4,10 +4,10 @@
 import importlib.metadata
 
 __title__: str = "mistralai"
-__version__: str = "2.4.5"
+__version__: str = "2.4.6"
 __openapi_doc_version__: str = "1.0.0"
 __gen_version__: str = "2.879.6"
-__user_agent__: str = "speakeasy-sdk/python 2.4.5 2.879.6 1.0.0 mistralai"
+__user_agent__: str = "speakeasy-sdk/python 2.4.6 2.879.6 1.0.0 mistralai"
 
 try:
     if __package__ is not None:

--- a/uv.lock
+++ b/uv.lock
@@ -1015,7 +1015,7 @@ wheels = [
 
 [[package]]
 name = "mistralai"
-version = "2.4.5"
+version = "2.4.6"
 source = { editable = "." }
 dependencies = [
     { name = "eval-type-backport" },


### PR DESCRIPTION
# SDK update
## Versioning

Version Bump Type: [patch] - 🤖 (automated)

> [!TIP]
> If updates to your OpenAPI document introduce breaking changes, be sure to update the `info.version` field to [trigger the correct version bump](https://www.speakeasy.com/docs/sdks/manage/versioning#openapi-document-changes).
> Speakeasy supports manual control of SDK versioning through [multiple methods](https://www.speakeasy.com/docs/sdks/manage/versioning#manual-version-bumps).
<details>
<summary>OpenAPI Change Summary</summary>
No specification changes

[View full report](https://app.speakeasy.com/org/mistral-dev/mistral-dev/changes-report/e9461c33d2e727eb6c724db40ba9ae4c)
</details>

<details>
<summary>Linting Report</summary>
0 errors, 6 warnings, 51 hints

[View full report](https://app.speakeasy.com/org/mistral-dev/mistral-dev/linting-report/1495f43cc5324c820c649a9de9112e19)
</details>

## PYTHON CHANGELOG
No relevant generator changes

<!-- execution_id: ea3d334e-c73e-56a2-9890-a073c9d94857 -->

Based on [Speakeasy CLI](https://github.com/speakeasy-api/speakeasy) 1.761.1

Last updated by [Speakeasy workflow](https://github.com/mistralai/client-python/actions/runs/25657723146)
