### PR TITLE
ci: publish Python SDKs to PyPI with OIDC

### DIFF
--- a/.github/workflows/sdk_publish_mistralai_sdk.yaml
+++ b/.github/workflows/sdk_publish_mistralai_sdk.yaml
@@ -1,9 +1,7 @@
 name: Publish MISTRALAI-SDK
 permissions:
-  checks: write
-  contents: write
-  pull-requests: write
-  statuses: write
+  contents: read
+  id-token: write
 "on":
   workflow_dispatch:
     inputs:
@@ -15,16 +13,66 @@ permissions:
     branches:
       - main
     paths:
-      - RELEASES.md
-      - "*/RELEASES.md"
+      - "**/RELEASES.md"
 jobs:
   publish:
+    name: Publish Python SDKs to PyPI
     # Auto-publish on push to main branch; require manual confirmation for workflow_dispatch
     if: |
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.confirm_publish == 'publish')
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@7951d9dce457425b900b2dd317253499d98c2587 # v15
-    secrets:
-      github_access_token: ${{ secrets.CLIENT_PIPELINE }}
-      pypi_token: ${{ secrets.PYPI_TOKEN }}
-      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
+    runs-on: ubuntu-latest
+    environment:
+      name: public-sdk
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+
+      - name: Build mistralai
+        run: |
+          python scripts/prepare_readme.py
+          uv build --sdist --wheel --out-dir dist/mistralai
+
+      - name: Publish mistralai to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13
+        with:
+          packages-dir: dist/mistralai/
+          print-hash: true
+          verbose: true
+          skip-existing: true
+
+      - name: Build mistralai-azure
+        working-directory: packages/azure
+        run: |
+          python scripts/prepare_readme.py
+          uv build --sdist --wheel --out-dir ../../dist/mistralai-azure
+
+      - name: Publish mistralai-azure to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13
+        with:
+          packages-dir: dist/mistralai-azure/
+          print-hash: true
+          verbose: true
+          skip-existing: true
+
+      - name: Build mistralai-gcp
+        working-directory: packages/gcp
+        run: |
+          python scripts/prepare_readme.py
+          uv build --sdist --wheel --out-dir ../../dist/mistralai-gcp
+
+      - name: Publish mistralai-gcp to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13
+        with:
+          packages-dir: dist/mistralai-gcp/
+          print-hash: true
+          verbose: true
+          skip-existing: true

--- a/.github/workflows/sdk_publish_mistralai_sdk.yaml
+++ b/.github/workflows/sdk_publish_mistralai_sdk.yaml
@@ -21,7 +21,7 @@ jobs:
     if: |
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.confirm_publish == 'publish')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment:
       name: public-sdk
     steps:

--- a/packages/azure/pyproject.toml
+++ b/packages/azure/pyproject.toml
@@ -20,6 +20,9 @@ dev = [
     "pytest-asyncio>=0.23.7,<0.24",
 ]
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [tool.setuptools.package-data]
 "*" = ["py.typed", "src/mistralai/azure/client/py.typed"]
 

--- a/packages/gcp/pyproject.toml
+++ b/packages/gcp/pyproject.toml
@@ -25,6 +25,9 @@ dev = [
     "types-python-dateutil>=2.9.0.20240316,<3",
 ]
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [tool.setuptools.package-data]
 "*" = ["py.typed", "src/mistralai/gcp/client/py.typed"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ lint = [
 ]
 
 [tool.uv]
+exclude-newer = "7 days"
 default-groups = [
     "dev",
     "lint",


### PR DESCRIPTION
## Summary
- replace the Speakeasy reusable PyPI publish workflow with a local publish job that uses GitHub OIDC trusted publishing
- keep the same publish triggers and package set: mistralai, mistralai-azure, and mistralai-gcp
- add uv exclude-newer = "7 days" to the root, Azure, and GCP projects

## PyPI registry setup still needed
- configure trusted publishers for the three PyPI projects with owner mistralai, repository client-python, workflow sdk_publish_mistralai_sdk.yaml, and environment public-sdk

## Verification
- git diff --check
- uv build for root, Azure, and GCP packages

## After merging
REMOVE THE PYPI TOKEN FROM THE CI AND INVALIDATE IT 🙏 