### PR TITLE
ci: split run_examples to keep PR runs unsecured and gate API runs to main

### DIFF
--- a/.github/workflows/run_example_scripts.yaml
+++ b/.github/workflows/run_example_scripts.yaml
@@ -10,7 +10,37 @@ on:
 
 jobs:
   run_examples:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+
+      - name: Build the package
+        run: |
+          uv build
+
+      - name: Install client with extras
+        run: |
+          PACKAGE="dist/$(ls dist | grep whl | head -n 1)[agents]"
+          uv pip install --system "$PACKAGE"
+
+  examples:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    environment: publish
     strategy:
       fail-fast: false
       matrix:
@@ -50,7 +80,7 @@ jobs:
           MISTRAL_API_KEY: ${{ env.MISTRAL_API_KEY }}
 
   run_examples_required:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: run_examples
     if: ${{ always() }}
 


### PR DESCRIPTION
## Summary
Split the examples workflow so that secret-using jobs only run on push to `main` behind an environment gate.

- `run_examples` (build + install, no secrets, no environment, runs on PR + push to main)
- `examples` (build + run examples with `CI_MISTRAL_API_KEY_PYTHON_*`, `environment: publish`, push-to-main only)
- Pins all runners to `ubuntu-24.04`

## Why
Today's workflow runs the API-key job on every PR with no environment gating. This change keeps PRs unblocked (build-only) and routes the API-key step through the `publish` environment so it requires reviewer approval before running.

## Verification
- `publish` environment already has all four `CI_MISTRAL_API_KEY_PYTHON_{310,311,312,313}` secrets
- Required reviewer: Engineering SDK team