### PR TITLE
ci: generate README-PYPI.md before aligning azure/gcp versions

### DIFF
--- a/.github/workflows/sdk_generation_mistralai_azure_sdk.yaml
+++ b/.github/workflows/sdk_generation_mistralai_azure_sdk.yaml
@@ -103,6 +103,11 @@ jobs:
         if: steps.branch-exists.outputs.exists == 'true'
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
 
+      - name: Generate README-PYPI.md
+        if: steps.branch-exists.outputs.exists == 'true'
+        working-directory: packages/azure
+        run: uv run python scripts/prepare_readme.py
+
       - name: Align version using uv
         if: steps.branch-exists.outputs.exists == 'true'
         run: |

--- a/.github/workflows/sdk_generation_mistralai_gcp_sdk.yaml
+++ b/.github/workflows/sdk_generation_mistralai_gcp_sdk.yaml
@@ -103,6 +103,11 @@ jobs:
         if: steps.branch-exists.outputs.exists == 'true'
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
 
+      - name: Generate README-PYPI.md
+        if: steps.branch-exists.outputs.exists == 'true'
+        working-directory: packages/gcp
+        run: uv run python scripts/prepare_readme.py
+
       - name: Align version using uv
         if: steps.branch-exists.outputs.exists == 'true'
         run: |


### PR DESCRIPTION
## Summary

The azure and gcp gen workflows fail at the `align-version` step because `uv version <new>` triggers a hatchling editable build that validates `pyproject.toml`. Both packages declare `readme = "README-PYPI.md"` but that file is generated at publish time by `scripts/prepare_readme.py` and not committed.

On fresh CI checkouts the file is missing, so hatchling raises:

```
OSError: Readme file does not exist: README-PYPI.md
```

before the version bump can complete.

## Fix

Run `scripts/prepare_readme.py` before `uv version` in both workflows, mirroring what `publish.sh` already does at release time.

## Validation

Reproduced the failure locally on `packages/azure` with the pinned hatchling: `uv version 2.0.1` failed with the exact same traceback. With the fix applied (running prepare_readme.py first), `uv version` succeeds.

This is a no-op on existing repo state — the workflow change only affects future gen runs.