### PR TITLE
docs: sync accesses delete description with current spec

### DIFF
--- a/docs/sdks/accesses/README.md
+++ b/docs/sdks/accesses/README.md
@@ -98,7 +98,7 @@ with Mistral(
 
 ## delete
 
-Given a library id, you can delete the access level of an entity. An owner cannot delete its own access. You have to be the owner of the library to delete an access other than yours.
+Given a library id, you can delete the access level of an entity. An owner cannot delete their own access. You have to be the owner of the library to delete an access other than yours. Warning: the response will change from 200 (returning the deleted sharing) to 204 No Content in a future version.
 
 ### Example Usage
 


### PR DESCRIPTION
## Summary

Every `speakeasy run -t mistralai-sdk` produces a 3-way merge conflict on `docs/sdks/accesses/README.md`:

```
both modified:   docs/sdks/accesses/README.md
could not apply persistent edits for "python": merge conflicts detected in 1 file(s)
```

The persistent-edits baseline in `.speakeasy/gen.lock` is anchored to text that the upstream OpenAPI spec updated months ago (typo fix `its own` → `their own` plus a deprecation warning about the response code changing from 200 to 204).

This blocks the entire mistralai-sdk gen workflow.

## Fix

Update the file in-tree to match the current spec text. This re-anchors the persistent edit so the next gen run completes cleanly.

The exact same text change was in the abandoned regen PR #522 (May 12, the incident date).

## Validation

Reproduced locally: with this change applied, `speakeasy run -t mistralai-sdk` completes successfully and re-anchors `pristine_commit_hash` in gen.lock.

## What comes next

After merging, the next workflow_dispatch on `sdk_generation_mistralai_sdk.yaml` will produce a normal regen PR with the accumulated spec changes since the last successful run. That PR goes through standard review → merge → publish env gate → release flow.