### PR TITLE
ci: commit README-PYPI.md for azure and gcp to match main package

### DIFF
--- a/.github/workflows/sdk_generation_mistralai_azure_sdk.yaml
+++ b/.github/workflows/sdk_generation_mistralai_azure_sdk.yaml
@@ -103,11 +103,6 @@ jobs:
         if: steps.branch-exists.outputs.exists == 'true'
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
 
-      - name: Generate README-PYPI.md
-        if: steps.branch-exists.outputs.exists == 'true'
-        working-directory: packages/azure
-        run: uv run python scripts/prepare_readme.py
-
       - name: Align version using uv
         if: steps.branch-exists.outputs.exists == 'true'
         run: |

--- a/.github/workflows/sdk_generation_mistralai_gcp_sdk.yaml
+++ b/.github/workflows/sdk_generation_mistralai_gcp_sdk.yaml
@@ -103,11 +103,6 @@ jobs:
         if: steps.branch-exists.outputs.exists == 'true'
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
 
-      - name: Generate README-PYPI.md
-        if: steps.branch-exists.outputs.exists == 'true'
-        working-directory: packages/gcp
-        run: uv run python scripts/prepare_readme.py
-
       - name: Align version using uv
         if: steps.branch-exists.outputs.exists == 'true'
         run: |

--- a/packages/azure/.gitignore
+++ b/packages/azure/.gitignore
@@ -4,7 +4,6 @@
 **/.speakeasy/temp/
 **/.speakeasy/logs/
 .speakeasy/reports
-README-PYPI.md
 .venv/
 venv/
 src/*.egg-info/

--- a/packages/azure/README-PYPI.md
+++ b/packages/azure/README-PYPI.md
@@ -1,0 +1,464 @@
+# Mistral on Azure Python Client
+
+## SDK Installation
+
+PIP
+```bash
+pip install mistralai
+```
+
+UV
+```bash
+uv add mistralai
+```
+
+**Prerequisites**
+
+Before you begin, ensure you have `AZURE_ENDPOINT` and an `AZURE_API_KEY`. To obtain these, you will need to deploy Mistral on Azure AI.
+See [instructions for deploying Mistral on Azure AI here](https://docs.mistral.ai/deployment/cloud/azure/).
+
+<!-- Start SDK Example Usage [usage] -->
+## SDK Example Usage
+
+### Create Chat Completions
+
+This example shows how to create chat completions.
+
+The SDK automatically injects the `api-version` query parameter.
+
+```python
+# Synchronous Example
+from mistralai.azure.client import MistralAzure
+import os
+
+AZURE_API_KEY = os.environ["AZURE_API_KEY"]
+AZURE_ENDPOINT = os.environ["AZURE_ENDPOINT"]
+AZURE_MODEL = os.environ["AZURE_MODEL"]
+AZURE_API_VERSION = os.environ.get("AZURE_API_VERSION", "2024-05-01-preview")
+
+# The SDK automatically injects api-version as a query parameter
+s = MistralAzure(
+    api_key=AZURE_API_KEY,
+    server_url=AZURE_ENDPOINT,
+    api_version=AZURE_API_VERSION,
+)
+
+res = s.chat.complete(
+    messages=[
+        {
+            "role": "user",
+            "content": "Who is the best French painter? Answer in one short sentence.",
+        },
+    ],
+    model=AZURE_MODEL,
+)
+
+if res is not None:
+    # handle response
+    print(res.choices[0].message.content)
+```
+
+<br/>
+
+The same SDK client can also be used to make asynchronous requests by importing asyncio.
+```python
+# Asynchronous Example
+import asyncio
+import os
+from mistralai.azure.client import MistralAzure
+
+AZURE_API_KEY = os.environ["AZURE_API_KEY"]
+AZURE_ENDPOINT = os.environ["AZURE_ENDPOINT"]
+AZURE_MODEL = os.environ["AZURE_MODEL"]
+AZURE_API_VERSION = os.environ.get("AZURE_API_VERSION", "2024-05-01-preview")
+
+async def main():
+    # The SDK automatically injects api-version as a query parameter
+    s = MistralAzure(
+        api_key=AZURE_API_KEY,
+        server_url=AZURE_ENDPOINT,
+        api_version=AZURE_API_VERSION,
+    )
+    res = await s.chat.complete_async(
+        messages=[
+            {
+                "role": "user",
+                "content": "Who is the best French painter? Answer in one short sentence.",
+            },
+        ],
+        model=AZURE_MODEL,
+    )
+    if res is not None:
+        # handle response
+        print(res.choices[0].message.content)
+
+asyncio.run(main())
+```
+<!-- End SDK Example Usage [usage] -->
+
+<!-- Start Available Resources and Operations [operations] -->
+## Available Resources and Operations
+
+### [chat](https://github.com/mistralai/client-python/blob/main/packages/azure/docs/sdks/chat/README.md)
+
+* [stream](https://github.com/mistralai/client-python/blob/main/packages/azure/docs/sdks/chat/README.md#stream) - Stream chat completion
+* [complete](https://github.com/mistralai/client-python/blob/main/packages/azure/docs/sdks/chat/README.md#complete) - Chat Completion
+<!-- End Available Resources and Operations [operations] -->
+
+<!-- Start Server-sent event streaming [eventstream] -->
+## Server-sent event streaming
+
+[Server-sent events][mdn-sse] are used to stream content from certain
+operations. These operations will expose the stream as [Generator][generator] that
+can be consumed using a simple `for` loop. The loop will
+terminate when the server no longer has any events to send and closes the
+underlying connection.
+
+```python
+from mistralai.azure.client import MistralAzure
+import os
+
+AZURE_API_KEY = os.environ["AZURE_API_KEY"]
+AZURE_ENDPOINT = os.environ["AZURE_ENDPOINT"]
+AZURE_MODEL = os.environ["AZURE_MODEL"]
+AZURE_API_VERSION = os.environ.get("AZURE_API_VERSION", "2024-05-01-preview")
+
+# The SDK automatically injects api-version as a query parameter
+s = MistralAzure(
+    api_key=AZURE_API_KEY,
+    server_url=AZURE_ENDPOINT,
+    api_version=AZURE_API_VERSION,
+)
+
+res = s.chat.stream(
+    messages=[
+        {
+            "role": "user",
+            "content": "Who is the best French painter? Answer in one short sentence.",
+        },
+    ],
+    model=AZURE_MODEL,
+)
+
+if res is not None:
+    for event in res:
+        # handle event
+        print(event)
+
+```
+
+[mdn-sse]: https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events
+[generator]: https://wiki.python.org/moin/Generators
+<!-- End Server-sent event streaming [eventstream] -->
+
+<!-- Start Retries [retries] -->
+## Retries
+
+Some of the endpoints in this SDK support retries. If you use the SDK without any configuration, it will fall back to the default retry strategy provided by the API. However, the default retry strategy can be overridden on a per-operation basis, or across the entire SDK.
+
+To change the default retry strategy for a single API call, simply provide a `RetryConfig` object to the call:
+```python
+from mistralai.azure.client import MistralAzure
+from mistralai.azure.client.utils import BackoffStrategy, RetryConfig
+import os
+
+AZURE_API_KEY = os.environ["AZURE_API_KEY"]
+AZURE_ENDPOINT = os.environ["AZURE_ENDPOINT"]
+AZURE_MODEL = os.environ["AZURE_MODEL"]
+AZURE_API_VERSION = os.environ.get("AZURE_API_VERSION", "2024-05-01-preview")
+
+# The SDK automatically injects api-version as a query parameter
+s = MistralAzure(
+    api_key=AZURE_API_KEY,
+    server_url=AZURE_ENDPOINT,
+    api_version=AZURE_API_VERSION,
+)
+
+res = s.chat.stream(
+    messages=[
+        {
+            "role": "user",
+            "content": "Who is the best French painter? Answer in one short sentence.",
+        },
+    ],
+    model=AZURE_MODEL,
+    retries=RetryConfig(
+        "backoff",
+        BackoffStrategy(1, 50, 1.1, 100),
+        False
+    ),
+)
+
+if res is not None:
+    for event in res:
+        # handle event
+        print(event)
+
+```
+
+If you'd like to override the default retry strategy for all operations that support retries, you can use the `retry_config` optional parameter when initializing the SDK:
+```python
+from mistralai.azure.client import MistralAzure
+from mistralai.azure.client.utils import BackoffStrategy, RetryConfig
+import os
+
+AZURE_API_KEY = os.environ["AZURE_API_KEY"]
+AZURE_ENDPOINT = os.environ["AZURE_ENDPOINT"]
+AZURE_MODEL = os.environ["AZURE_MODEL"]
+AZURE_API_VERSION = os.environ["AZURE_API_VERSION"]
+
+# The SDK automatically injects api-version as a query parameter
+s = MistralAzure(
+    api_key=AZURE_API_KEY,
+    server_url=AZURE_ENDPOINT,
+    api_version=AZURE_API_VERSION,
+    retry_config=RetryConfig("backoff", BackoffStrategy(1, 50, 1.1, 100), False),
+)
+
+res = s.chat.stream(
+    messages=[
+        {
+            "role": "user",
+            "content": "Who is the best French painter? Answer in one short sentence.",
+        },
+    ],
+    model=AZURE_MODEL,
+)
+
+if res is not None:
+    for event in res:
+        # handle event
+        print(event)
+
+```
+<!-- End Retries [retries] -->
+
+<!-- Start Error Handling [errors] -->
+## Error Handling
+
+Handling errors in this SDK should largely match your expectations. All operations return a response object or raise an error. If Error objects are specified in your OpenAPI Spec, the SDK will raise the appropriate Error type.
+
+| Error Object               | Status Code | Content Type     |
+| -------------------------- | ----------- | ---------------- |
+| models.HTTPValidationError | 422         | application/json |
+| models.SDKError            | 4xx-5xx     | */*              |
+
+### Example
+
+```python
+from mistralai.azure.client import MistralAzure
+from mistralai.azure.client import models
+import os
+
+AZURE_API_KEY = os.environ["AZURE_API_KEY"]
+AZURE_ENDPOINT = os.environ["AZURE_ENDPOINT"]
+AZURE_MODEL = os.environ["AZURE_MODEL"]
+AZURE_API_VERSION = os.environ.get("AZURE_API_VERSION", "2024-05-01-preview")
+
+# The SDK automatically injects api-version as a query parameter
+s = MistralAzure(
+    api_key=AZURE_API_KEY,
+    server_url=AZURE_ENDPOINT,
+    api_version=AZURE_API_VERSION,
+)
+
+res = None
+try:
+    res = s.chat.complete(
+        messages=[
+            {
+                "role": "user",
+                "content": "Who is the best French painter? Answer in one short sentence.",
+            },
+        ],
+        model=AZURE_MODEL,
+    )
+
+except models.HTTPValidationError as e:
+    # handle exception
+    raise(e)
+except models.SDKError as e:
+    # handle exception
+    raise(e)
+
+if res is not None:
+    # handle response
+    pass
+
+```
+<!-- End Error Handling [errors] -->
+
+<!-- Start Server Selection [server] -->
+## Server Selection
+
+### Override Server URL Per-Client
+
+For Azure, you must provide your Azure AI Foundry endpoint via `server_url`. The SDK automatically injects the `api-version` query parameter:
+```python
+from mistralai.azure.client import MistralAzure
+import os
+
+s = MistralAzure(
+    api_key=os.environ["AZURE_API_KEY"],
+    server_url=os.environ["AZURE_ENDPOINT"],
+    api_version=os.environ.get("AZURE_API_VERSION", "2024-05-01-preview"),
+)
+
+res = s.chat.stream(
+    messages=[
+        {
+            "role": "user",
+            "content": "Who is the best French painter? Answer in one short sentence.",
+        },
+    ],
+    model=os.environ["AZURE_MODEL"],
+)
+
+if res is not None:
+    for event in res:
+        # handle event
+        print(event)
+
+```
+<!-- End Server Selection [server] -->
+
+<!-- Start Custom HTTP Client [http-client] -->
+## Custom HTTP Client
+
+The Python SDK makes API calls using the [httpx](https://www.python-httpx.org/) HTTP library.  In order to provide a convenient way to configure timeouts, cookies, proxies, custom headers, and other low-level configuration, you can initialize the SDK client with your own HTTP client instance.
+Depending on whether you are using the sync or async version of the SDK, you can pass an instance of `HttpClient` or `AsyncHttpClient` respectively, which are Protocols ensuring that the client has the necessary methods to make API calls.
+This allows you to wrap the client with your own custom logic, such as adding custom headers, logging, or error handling, or you can just pass an instance of `httpx.Client` or `httpx.AsyncClient` directly.
+
+For example, you could specify a header for every request that this SDK makes as follows:
+```python
+from mistralai.azure.client import MistralAzure
+import httpx
+import os
+
+http_client = httpx.Client(headers={"x-custom-header": "someValue"})
+s = MistralAzure(
+    api_key=os.environ["AZURE_API_KEY"],
+    server_url=os.environ["AZURE_ENDPOINT"],
+    api_version=os.environ.get("AZURE_API_VERSION", "2024-05-01-preview"),
+    client=http_client,
+)
+```
+
+or you could wrap the client with your own custom logic:
+```python
+from typing import Any, Optional, Union
+from mistralai.azure.client import MistralAzure
+from mistralai.azure.client.httpclient import AsyncHttpClient
+import httpx
+
+class CustomClient(AsyncHttpClient):
+    client: AsyncHttpClient
+
+    def __init__(self, client: AsyncHttpClient):
+        self.client = client
+
+    async def send(
+        self,
+        request: httpx.Request,
+        *,
+        stream: bool = False,
+        auth: Union[
+            httpx._types.AuthTypes, httpx._client.UseClientDefault, None
+        ] = httpx.USE_CLIENT_DEFAULT,
+        follow_redirects: Union[
+            bool, httpx._client.UseClientDefault
+        ] = httpx.USE_CLIENT_DEFAULT,
+    ) -> httpx.Response:
+        request.headers["Client-Level-Header"] = "added by client"
+
+        return await self.client.send(
+            request, stream=stream, auth=auth, follow_redirects=follow_redirects
+        )
+
+    def build_request(
+        self,
+        method: str,
+        url: httpx._types.URLTypes,
+        *,
+        content: Optional[httpx._types.RequestContent] = None,
+        data: Optional[httpx._types.RequestData] = None,
+        files: Optional[httpx._types.RequestFiles] = None,
+        json: Optional[Any] = None,
+        params: Optional[httpx._types.QueryParamTypes] = None,
+        headers: Optional[httpx._types.HeaderTypes] = None,
+        cookies: Optional[httpx._types.CookieTypes] = None,
+        timeout: Union[
+            httpx._types.TimeoutTypes, httpx._client.UseClientDefault
+        ] = httpx.USE_CLIENT_DEFAULT,
+        extensions: Optional[httpx._types.RequestExtensions] = None,
+    ) -> httpx.Request:
+        return self.client.build_request(
+            method,
+            url,
+            content=content,
+            data=data,
+            files=files,
+            json=json,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            timeout=timeout,
+            extensions=extensions,
+        )
+
+s = MistralAzure(
+    api_key="<your-azure-api-key>",
+    server_url="<your-azure-endpoint>",
+    async_client=CustomClient(httpx.AsyncClient()),
+)
+```
+<!-- End Custom HTTP Client [http-client] -->
+
+<!-- Start Authentication [security] -->
+## Authentication
+
+### Per-Client Security Schemes
+
+This SDK supports the following security scheme globally:
+
+| Name      | Type | Scheme      |
+| --------- | ---- | ----------- |
+| `api_key` | http | HTTP Bearer |
+
+To authenticate with the API the `api_key` parameter must be set when initializing the SDK client instance. You must also provide `server_url` pointing to your Azure AI Foundry endpoint. The SDK automatically injects the `api-version` query parameter:
+```python
+from mistralai.azure.client import MistralAzure
+import os
+
+s = MistralAzure(
+    api_key=os.environ["AZURE_API_KEY"],
+    server_url=os.environ["AZURE_ENDPOINT"],
+    api_version=os.environ.get("AZURE_API_VERSION", "2024-05-01-preview"),
+)
+
+res = s.chat.stream(
+    messages=[
+        {
+            "role": "user",
+            "content": "Who is the best French painter? Answer in one short sentence.",
+        },
+    ],
+    model=os.environ["AZURE_MODEL"],
+)
+
+if res is not None:
+    for event in res:
+        # handle event
+        print(event)
+
+```
+<!-- End Authentication [security] -->
+
+<!-- Placeholder for Future Speakeasy SDK Sections -->
+
+# Development
+
+## Contributions
+
+While we value open-source contributions to this SDK, this library is generated programmatically. Any manual changes added to internal files will be overwritten on the next generation.
+We look forward to hearing your feedback. Feel free to open a PR or an issue with a proof of concept and we'll do our best to include it in a future release.

--- a/packages/gcp/.gitignore
+++ b/packages/gcp/.gitignore
@@ -4,7 +4,6 @@
 **/.speakeasy/temp/
 **/.speakeasy/logs/
 .speakeasy/reports
-README-PYPI.md
 .venv/
 venv/
 src/*.egg-info/

--- a/packages/gcp/README-PYPI.md
+++ b/packages/gcp/README-PYPI.md
@@ -1,0 +1,428 @@
+# Mistral on GCP Python Client
+
+
+**Prerequisites**
+
+Before you begin, you will need to create a Google Cloud project and enable the Mistral API. To do this, follow the instructions [here](https://docs.mistral.ai/deployment/cloud/vertex/).
+
+To run this locally you will also need to ensure you are authenticated with Google Cloud. You can do this by running
+
+```bash
+gcloud auth application-default login
+```
+
+## SDK Installation
+
+Install the extras dependencies specific to Google Cloud:
+
+```bash
+pip install mistralai[gcp]
+```
+
+<!-- Start SDK Example Usage [usage] -->
+## SDK Example Usage
+
+### Create Chat Completions
+
+This example shows how to create chat completions.
+
+The SDK automatically:
+- Detects credentials via `google.auth.default()`
+- Auto-refreshes tokens when they expire
+- Builds the Vertex AI URL from `project_id` and `region`
+
+```python
+# Synchronous Example
+import os
+from mistralai.gcp.client import MistralGCP
+
+# The SDK auto-detects credentials and builds the Vertex AI URL
+s = MistralGCP(
+    project_id=os.environ.get("GCP_PROJECT_ID"),  # Optional: auto-detected from credentials
+    region=os.environ.get("GCP_REGION", "us-central1"),
+)
+
+res = s.chat.complete(messages=[
+    {
+        "role": "user",
+        "content": "Who is the best French painter? Answer in one short sentence.",
+    },
+], model="mistral-small-2503")
+
+if res is not None:
+    # handle response
+    print(res.choices[0].message.content)
+```
+
+<br/>
+
+The same SDK client can also be used to make asynchronous requests by importing asyncio.
+```python
+# Asynchronous Example
+import asyncio
+import os
+from mistralai.gcp.client import MistralGCP
+
+async def main():
+    # The SDK auto-detects credentials and builds the Vertex AI URL
+    s = MistralGCP(
+        project_id=os.environ.get("GCP_PROJECT_ID"),  # Optional: auto-detected
+        region=os.environ.get("GCP_REGION", "us-central1"),
+    )
+    res = await s.chat.complete_async(messages=[
+        {
+            "role": "user",
+            "content": "Who is the best French painter? Answer in one short sentence.",
+        },
+    ], model="mistral-small-2503")
+    if res is not None:
+        # handle response
+        print(res.choices[0].message.content)
+
+asyncio.run(main())
+```
+<!-- End SDK Example Usage [usage] -->
+
+<!-- Start Available Resources and Operations [operations] -->
+## Available Resources and Operations
+
+### [chat](https://github.com/mistralai/client-python/blob/main/packages/gcp/docs/sdks/chat/README.md)
+
+* [stream](https://github.com/mistralai/client-python/blob/main/packages/gcp/docs/sdks/chat/README.md#stream) - Stream chat completion
+* [complete](https://github.com/mistralai/client-python/blob/main/packages/gcp/docs/sdks/chat/README.md#complete) - Chat Completion
+
+### [fim](https://github.com/mistralai/client-python/blob/main/packages/gcp/docs/sdks/fim/README.md)
+
+* [stream](https://github.com/mistralai/client-python/blob/main/packages/gcp/docs/sdks/fim/README.md#stream) - Stream fim completion
+* [complete](https://github.com/mistralai/client-python/blob/main/packages/gcp/docs/sdks/fim/README.md#complete) - Fim Completion
+<!-- End Available Resources and Operations [operations] -->
+
+<!-- Start Server-sent event streaming [eventstream] -->
+## Server-sent event streaming
+
+[Server-sent events][mdn-sse] are used to stream content from certain
+operations. These operations will expose the stream as [Generator][generator] that
+can be consumed using a simple `for` loop. The loop will
+terminate when the server no longer has any events to send and closes the
+underlying connection.
+
+```python
+import os
+from mistralai.gcp.client import MistralGCP
+
+# The SDK auto-detects credentials and builds the Vertex AI URL
+s = MistralGCP(
+    project_id=os.environ.get("GCP_PROJECT_ID"),  # Optional: auto-detected
+    region=os.environ.get("GCP_REGION", "us-central1"),
+)
+
+res = s.chat.stream(messages=[
+    {
+        "role": "user",
+        "content": "Who is the best French painter? Answer in one short sentence.",
+    },
+], model="mistral-small-2503")
+
+if res is not None:
+    for event in res:
+        # handle event
+        print(event)
+
+```
+
+[mdn-sse]: https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events
+[generator]: https://wiki.python.org/moin/Generators
+<!-- End Server-sent event streaming [eventstream] -->
+
+<!-- Start Retries [retries] -->
+## Retries
+
+Some of the endpoints in this SDK support retries. If you use the SDK without any configuration, it will fall back to the default retry strategy provided by the API. However, the default retry strategy can be overridden on a per-operation basis, or across the entire SDK.
+
+To change the default retry strategy for a single API call, simply provide a `RetryConfig` object to the call:
+```python
+import os
+from mistralai.gcp.client import MistralGCP
+from mistralai.gcp.client.utils import BackoffStrategy, RetryConfig
+
+# The SDK auto-detects credentials and builds the Vertex AI URL
+s = MistralGCP(
+    project_id=os.environ.get("GCP_PROJECT_ID"),  # Optional: auto-detected
+    region=os.environ.get("GCP_REGION", "us-central1"),
+)
+
+res = s.chat.stream(
+    messages=[
+        {
+            "role": "user",
+            "content": "Who is the best French painter? Answer in one short sentence.",
+        },
+    ],
+    model="mistral-small-2503",
+    retries=RetryConfig(
+        "backoff",
+        BackoffStrategy(1, 50, 1.1, 100),
+        False
+    )
+)
+
+if res is not None:
+    for event in res:
+        # handle event
+        print(event)
+
+```
+
+If you'd like to override the default retry strategy for all operations that support retries, you can use the `retry_config` optional parameter when initializing the SDK:
+```python
+import os
+from mistralai.gcp.client import MistralGCP
+from mistralai.gcp.client.utils import BackoffStrategy, RetryConfig
+
+# The SDK auto-detects credentials and builds the Vertex AI URL
+s = MistralGCP(
+    project_id=os.environ.get("GCP_PROJECT_ID"),
+    region=os.environ.get("GCP_REGION", "us-central1"),
+    retry_config=RetryConfig("backoff", BackoffStrategy(1, 50, 1.1, 100), False),
+)
+
+res = s.chat.stream(
+    messages=[
+        {
+            "role": "user",
+            "content": "Who is the best French painter? Answer in one short sentence.",
+        },
+    ],
+    model="mistral-small-2503",
+)
+
+if res is not None:
+    for event in res:
+        # handle event
+        print(event)
+
+```
+<!-- End Retries [retries] -->
+
+<!-- Start Error Handling [errors] -->
+## Error Handling
+
+Handling errors in this SDK should largely match your expectations. All operations return a response object or raise an error. If Error objects are specified in your OpenAPI Spec, the SDK will raise the appropriate Error type.
+
+| Error Object               | Status Code | Content Type     |
+| -------------------------- | ----------- | ---------------- |
+| models.HTTPValidationError | 422         | application/json |
+| models.SDKError            | 4xx-5xx     | */*              |
+
+### Example
+
+```python
+import os
+from mistralai.gcp.client import MistralGCP
+from mistralai.gcp.client import models
+
+# The SDK auto-detects credentials and builds the Vertex AI URL
+s = MistralGCP(
+    project_id=os.environ.get("GCP_PROJECT_ID"),
+    region=os.environ.get("GCP_REGION", "us-central1"),
+)
+
+res = None
+try:
+    res = s.chat.complete(
+        messages=[
+            {
+                "role": "user",
+                "content": "Who is the best French painter? Answer in one short sentence.",
+            },
+        ],
+        model="mistral-small-2503",
+    )
+
+except models.HTTPValidationError as e:
+    # handle exception
+    raise(e)
+except models.SDKError as e:
+    # handle exception
+    raise(e)
+
+if res is not None:
+    # handle response
+    pass
+
+```
+<!-- End Error Handling [errors] -->
+
+<!-- Start Server Selection [server] -->
+## Server Selection
+
+### Override Server URL Per-Client
+
+The SDK automatically constructs the Vertex AI endpoint from `project_id` and `region`:
+```python
+import os
+from mistralai.gcp.client import MistralGCP
+
+# The SDK auto-detects credentials and builds the Vertex AI URL
+s = MistralGCP(
+    project_id=os.environ.get("GCP_PROJECT_ID"),  # Optional: auto-detected
+    region=os.environ.get("GCP_REGION", "us-central1"),
+)
+
+res = s.chat.stream(
+    messages=[
+        {
+            "role": "user",
+            "content": "Who is the best French painter? Answer in one short sentence.",
+        },
+    ],
+    model="mistral-small-2503",
+)
+
+if res is not None:
+    for event in res:
+        # handle event
+        print(event)
+
+```
+<!-- End Server Selection [server] -->
+
+<!-- Start Custom HTTP Client [http-client] -->
+## Custom HTTP Client
+
+The Python SDK makes API calls using the [httpx](https://www.python-httpx.org/) HTTP library.  In order to provide a convenient way to configure timeouts, cookies, proxies, custom headers, and other low-level configuration, you can initialize the SDK client with your own HTTP client instance.
+Depending on whether you are using the sync or async version of the SDK, you can pass an instance of `HttpClient` or `AsyncHttpClient` respectively, which are Protocols ensuring that the client has the necessary methods to make API calls.
+This allows you to wrap the client with your own custom logic, such as adding custom headers, logging, or error handling, or you can just pass an instance of `httpx.Client` or `httpx.AsyncClient` directly.
+
+For example, you could specify a header for every request that this SDK makes as follows:
+```python
+import os
+from mistralai.gcp.client import MistralGCP
+import httpx
+
+http_client = httpx.Client(headers={"x-custom-header": "someValue"})
+s = MistralGCP(
+    project_id=os.environ.get("GCP_PROJECT_ID"),
+    region="us-central1",
+    client=http_client,
+)
+```
+
+or you could wrap the client with your own custom logic:
+```python
+from typing import Any, Optional, Union
+from mistralai.gcp.client import MistralGCP
+from mistralai.gcp.client.httpclient import AsyncHttpClient
+import httpx
+
+class CustomClient(AsyncHttpClient):
+    client: AsyncHttpClient
+
+    def __init__(self, client: AsyncHttpClient):
+        self.client = client
+
+    async def send(
+        self,
+        request: httpx.Request,
+        *,
+        stream: bool = False,
+        auth: Union[
+            httpx._types.AuthTypes, httpx._client.UseClientDefault, None
+        ] = httpx.USE_CLIENT_DEFAULT,
+        follow_redirects: Union[
+            bool, httpx._client.UseClientDefault
+        ] = httpx.USE_CLIENT_DEFAULT,
+    ) -> httpx.Response:
+        request.headers["Client-Level-Header"] = "added by client"
+
+        return await self.client.send(
+            request, stream=stream, auth=auth, follow_redirects=follow_redirects
+        )
+
+    def build_request(
+        self,
+        method: str,
+        url: httpx._types.URLTypes,
+        *,
+        content: Optional[httpx._types.RequestContent] = None,
+        data: Optional[httpx._types.RequestData] = None,
+        files: Optional[httpx._types.RequestFiles] = None,
+        json: Optional[Any] = None,
+        params: Optional[httpx._types.QueryParamTypes] = None,
+        headers: Optional[httpx._types.HeaderTypes] = None,
+        cookies: Optional[httpx._types.CookieTypes] = None,
+        timeout: Union[
+            httpx._types.TimeoutTypes, httpx._client.UseClientDefault
+        ] = httpx.USE_CLIENT_DEFAULT,
+        extensions: Optional[httpx._types.RequestExtensions] = None,
+    ) -> httpx.Request:
+        return self.client.build_request(
+            method,
+            url,
+            content=content,
+            data=data,
+            files=files,
+            json=json,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            timeout=timeout,
+            extensions=extensions,
+        )
+
+s = MistralGCP(
+    project_id="<your-project-id>",
+    region="us-central1",
+    async_client=CustomClient(httpx.AsyncClient()),
+)
+```
+<!-- End Custom HTTP Client [http-client] -->
+
+<!-- Start Authentication [security] -->
+## Authentication
+
+### Per-Client Security Schemes
+
+This SDK supports the following security scheme globally:
+
+| Name      | Type | Scheme      |
+| --------- | ---- | ----------- |
+| `api_key` | http | HTTP Bearer |
+
+The SDK automatically handles GCP authentication via `google.auth.default()`. Tokens are auto-refreshed when they expire. For example:
+```python
+import os
+from mistralai.gcp.client import MistralGCP
+
+# The SDK auto-detects credentials and builds the Vertex AI URL
+s = MistralGCP(
+    project_id=os.environ.get("GCP_PROJECT_ID"),  # Optional: auto-detected
+    region=os.environ.get("GCP_REGION", "us-central1"),
+)
+
+res = s.chat.stream(
+    messages=[
+        {
+            "role": "user",
+            "content": "Who is the best French painter? Answer in one short sentence.",
+        },
+    ],
+    model="mistral-small-2503",
+)
+
+if res is not None:
+    for event in res:
+        # handle event
+        print(event)
+
+```
+<!-- End Authentication [security] -->
+
+<!-- Placeholder for Future Speakeasy SDK Sections -->
+
+# Development
+
+## Contributions
+
+While we value open-source contributions to this SDK, this library is generated programmatically. Any manual changes added to internal files will be overwritten on the next generation.
+We look forward to hearing your feedback. Feel free to open a PR or an issue with a proof of concept and we'll do our best to include it in a future release.


### PR DESCRIPTION
## Summary

The fix in #537 (run prepare_readme.py before align-version) fails in CI because `uv run python` syncs the project before executing, which builds the package, which validates pyproject.toml, which requires README-PYPI.md to exist. Chicken-and-egg.

The cleaner fix is the pattern the root mistralai package already uses: commit `README-PYPI.md` directly. Root package has done this since #518 and align-version works fine there.

## Changes

- Remove `README-PYPI.md` from `packages/azure/.gitignore` and `packages/gcp/.gitignore`
- Commit freshly-generated `packages/azure/README-PYPI.md` and `packages/gcp/README-PYPI.md` (produced by running `python3 scripts/prepare_readme.py` in each package)
- Drop the prepare_readme step from `sdk_generation_mistralai_{azure,gcp}_sdk.yaml` (added in #537) since the file is now always present on disk
- `scripts/prepare_readme.py` is still called by `publish.sh` and the publish workflow to refresh the file at release time, so it stays accurate
- The README-PYPI content is identical to README.md except all relative links are rewritten to absolute `https://github.com/...` URLs so PyPI renders correctly

## Why not use `python3 scripts/prepare_readme.py` (plain) in the workflow instead?

That would also work (the script is stdlib-only). But committing the file matches what the main package already does, is one less moving part in CI, and keeps the README-PYPI content visible in code review whenever it changes.

## Validation

Failure reproduced on run [26233248070](https://github.com/mistralai/client-python/actions/runs/26233248070) and [26233250646](https://github.com/mistralai/client-python/actions/runs/26233250646) — same hatchling `OSError: Readme file does not exist` from `uv run`. After this PR merges, neither will recur since the file is committed.