### PR TITLE
Use msgpack for compressed workflow payloads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "opentelemetry-api (>=1.33.1,<2.0.0)",
     "opentelemetry-semantic-conventions (>=0.60b1,<0.61)",
     "jsonpath-python >=1.0.6", # required for speakeasy generated path with pagination
+    "msgpack>=1.1.0,<2.0.0",
 ]
 
 [project.optional-dependencies]
@@ -50,7 +51,6 @@ workflow_payload_encryption = [
     "cryptography>=41.0.0,<47.0.0",
 ]
 workflow_payload_compression = [
-    "msgpack>=1.1.0,<2.0.0",
     "zstandard>=0.25.0,<0.26",
 ]
 
@@ -74,7 +74,6 @@ dev = [
     "griffe>=1.7.3,<2",
     "authlib>=1.5.2,<2",
     "websockets >=13.0",
-    "msgpack>=1.1.0,<2.0.0",
     "zstandard>=0.25.0,<0.26",
 ]
 lint = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ workflow_payload_encryption = [
     "cryptography>=41.0.0,<47.0.0",
 ]
 workflow_payload_compression = [
+    "msgpack>=1.1.0,<2.0.0",
     "zstandard>=0.25.0,<0.26",
 ]
 
@@ -73,6 +74,7 @@ dev = [
     "griffe>=1.7.3,<2",
     "authlib>=1.5.2,<2",
     "websockets >=13.0",
+    "msgpack>=1.1.0,<2.0.0",
     "zstandard>=0.25.0,<0.26",
 ]
 lint = [
@@ -141,6 +143,7 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = [
     "jsonpath.*",
+    "msgpack.*",
     "typing_inspect.*",
     "authlib.*",
     "websockets.*",

--- a/src/mistralai/extra/tests/test_workflow_encoding.py
+++ b/src/mistralai/extra/tests/test_workflow_encoding.py
@@ -3,6 +3,7 @@
 import gc
 import json
 
+import msgpack
 import pytest
 import zstandard
 from pydantic import SecretStr
@@ -42,18 +43,21 @@ _COMPRESSED_TEST_PAYLOAD = CompressedPayloadData.from_payload(
 )
 
 
-def _compressed_payload_json(
+def _compressed_payload_msgpack(
     compressed_payload: CompressedPayloadData,
     *,
     invalid_compression: dict[str, object] | None = None,
-    invalid_base64: bool = False,
+    invalid_payload: object | None = None,
 ) -> bytes:
-    payload_data = compressed_payload.model_dump(mode="json")
+    payload_data: dict[str, object] = {
+        "compression": compressed_payload.compression.model_dump(mode="json"),
+        "payload": compressed_payload.payload,
+    }
     if invalid_compression is not None:
         payload_data["compression"] = invalid_compression
-    if invalid_base64:
-        payload_data["b64payload"] = f"{payload_data['b64payload']}!"
-    return json.dumps(payload_data).encode()
+    if invalid_payload is not None:
+        payload_data["payload"] = invalid_payload
+    return msgpack.packb(payload_data, use_bin_type=True)
 
 
 @pytest.fixture
@@ -191,9 +195,7 @@ async def test_payload_encoder_compresses_network_inputs():
     )
 
     assert encoded.encoding_options == [EncodedPayloadOptions.COMPRESSED]
-    compressed_payload = CompressedPayloadData.model_validate_json(
-        encoded.get_payload()
-    )
+    compressed_payload = CompressedPayloadData.from_msgpack(encoded.get_payload())
     assert compressed_payload.compression == ZstdCompressionConfig(level=3)
 
     decoded = await encoder.decode_network_result(encoded.model_dump(mode="json"))
@@ -235,7 +237,7 @@ async def test_payload_encoder_wraps_compression_config_in_payload_content():
     encoded_data, encoding_options = await encoder.encode_payload_content(
         raw, WorkflowContext(namespace="test", execution_id="exec")
     )
-    compressed_payload = CompressedPayloadData.model_validate_json(encoded_data)
+    compressed_payload = CompressedPayloadData.from_msgpack(encoded_data)
 
     assert encoding_options == [EncodedPayloadOptions.COMPRESSED]
     assert compressed_payload.compression == ZstdCompressionConfig(level=3)
@@ -380,9 +382,7 @@ async def test_payload_encoder_decodes_compressed_payload_with_decoder_config(
     )
 
     assert encoded.encoding_options == [EncodedPayloadOptions.COMPRESSED]
-    compressed_payload = CompressedPayloadData.model_validate_json(
-        encoded.get_payload()
-    )
+    compressed_payload = CompressedPayloadData.from_msgpack(encoded.get_payload())
     assert compressed_payload.compression == ZstdCompressionConfig(level=22)
     assert decoded == payload
 
@@ -458,14 +458,12 @@ async def test_payload_encoder_decodes_with_tampered_compression_level():
     encoded = await encoder.encode_network_input(
         payload, WorkflowContext(namespace="test", execution_id="exec")
     )
-    compressed_payload = CompressedPayloadData.model_validate_json(
-        encoded.get_payload()
-    )
+    compressed_payload = CompressedPayloadData.from_msgpack(encoded.get_payload())
     tampered_payload = compressed_payload.model_copy(
         update={"compression": ZstdCompressionConfig(level=1)}
     )
     tampered = NetworkEncodedInput.from_data(
-        tampered_payload.model_dump_json().encode(), encoded.encoding_options
+        tampered_payload.to_msgpack(), encoded.encoding_options
     )
 
     decoded = await PayloadEncoder(WorkflowEncodingConfig()).decode_network_result(
@@ -480,15 +478,18 @@ async def test_payload_encoder_decodes_with_tampered_compression_level():
     "compressed_payload",
     [
         b"compressed-data",
-        _compressed_payload_json(
+        _compressed_payload_msgpack(
             _COMPRESSED_TEST_PAYLOAD,
             invalid_compression={"algorithm": "lz4", "level": 1},
         ),
-        _compressed_payload_json(
+        _compressed_payload_msgpack(
             _COMPRESSED_TEST_PAYLOAD,
             invalid_compression={"level": 3},
         ),
-        _compressed_payload_json(_COMPRESSED_TEST_PAYLOAD, invalid_base64=True),
+        _compressed_payload_msgpack(
+            _COMPRESSED_TEST_PAYLOAD,
+            invalid_payload=123,
+        ),
     ],
 )
 async def test_payload_encoder_invalid_compressed_payload_is_error(
@@ -510,7 +511,7 @@ async def test_payload_encoder_corrupted_compressed_data_is_error():
         b"corrupted-data", ZstdCompressionConfig(level=3)
     )
     encoded = NetworkEncodedInput.from_data(
-        compressed_payload.model_dump_json().encode(),
+        compressed_payload.to_msgpack(),
         [EncodedPayloadOptions.COMPRESSED],
     )
 

--- a/src/mistralai/extra/workflows/encoding/models.py
+++ b/src/mistralai/extra/workflows/encoding/models.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Literal, Optional
+from typing import Literal, Optional
 
 import base64
 from pydantic import BaseModel, Field
@@ -36,10 +36,6 @@ class EncodedPayload(BaseModel):
     encoding_options: list[EncodedPayloadOptions] = Field(
         description="The encoding of the payload", default=[]
     )
-    encoding_metadata: dict[str, Any] = Field(
-        description="Additional metadata required to decode the payload",
-        default_factory=dict,
-    )
     payload: bytes = Field(description="The encoded payload")
 
 
@@ -47,10 +43,6 @@ class NetworkEncodedBase(BaseModel):
     b64payload: str = Field(description="The encoded payload")
     encoding_options: list[EncodedPayloadOptions] = Field(
         description="The encoding of the payload", default=[]
-    )
-    encoding_metadata: dict[str, Any] = Field(
-        description="Additional metadata required to decode the payload",
-        default_factory=dict,
     )
 
     def get_payload(self) -> bytes:
@@ -66,7 +58,6 @@ class NetworkEncodedInput(NetworkEncodedBase):
         return EncodedPayload(
             payload=base64.b64decode(self.b64payload),
             encoding_options=self.encoding_options,
-            encoding_metadata=self.encoding_metadata,
             context=WorkflowContext(
                 namespace=namespace,
                 execution_id=execution_id,
@@ -79,19 +70,16 @@ class NetworkEncodedInput(NetworkEncodedBase):
         return NetworkEncodedInput(
             b64payload=base64.b64encode(encoded_payload.payload).decode("utf-8"),
             encoding_options=encoded_payload.encoding_options,
-            encoding_metadata=encoded_payload.encoding_metadata,
         )
 
     @staticmethod
     def from_data(
         data: bytes,
         encoding_options: list[EncodedPayloadOptions],
-        encoding_metadata: dict[str, Any] | None = None,
     ) -> "NetworkEncodedInput":
         return NetworkEncodedInput(
             b64payload=base64.b64encode(data).decode("utf-8"),
             encoding_options=encoding_options,
-            encoding_metadata=encoding_metadata or {},
         )
 
 
@@ -101,5 +89,4 @@ class NetworkEncodedResult(NetworkEncodedBase):
         return NetworkEncodedResult(
             b64payload=base64.b64encode(encoded_payload.payload).decode("utf-8"),
             encoding_options=encoded_payload.encoding_options,
-            encoding_metadata=encoded_payload.encoding_metadata,
         )

--- a/src/mistralai/extra/workflows/encoding/payload_compressor.py
+++ b/src/mistralai/extra/workflows/encoding/payload_compressor.py
@@ -39,6 +39,15 @@ def _require_zstandard() -> ModuleType:
         ) from None
 
 
+def _require_msgpack() -> ModuleType:
+    try:
+        return import_module("msgpack")
+    except ImportError:
+        raise WorkflowPayloadCompressionException(
+            "Payload compression requires installing mistralai[workflow_payload_compression]"
+        ) from None
+
+
 class ZstdCompressor(Compressor):
     @property
     def algorithm_config(self) -> AlgorithmConfig:

--- a/src/mistralai/extra/workflows/encoding/payload_compressor.py
+++ b/src/mistralai/extra/workflows/encoding/payload_compressor.py
@@ -39,15 +39,6 @@ def _require_zstandard() -> ModuleType:
         ) from None
 
 
-def _require_msgpack() -> ModuleType:
-    try:
-        return import_module("msgpack")
-    except ImportError:
-        raise WorkflowPayloadCompressionException(
-            "Payload compression requires installing mistralai[workflow_payload_compression]"
-        ) from None
-
-
 class ZstdCompressor(Compressor):
     @property
     def algorithm_config(self) -> AlgorithmConfig:

--- a/src/mistralai/extra/workflows/encoding/payload_encoder.py
+++ b/src/mistralai/extra/workflows/encoding/payload_encoder.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import base64
-import binascii
 import functools
 import hashlib
 import json
@@ -58,26 +57,53 @@ class OffloadedPayloadData(BaseModel):
     key: str
 
 
+def _require_msgpack() -> Any:
+    try:
+        return __import__("msgpack")
+    except ImportError:
+        raise WorkflowPayloadCompressionException(
+            "Payload compression requires installing mistralai[workflow_payload_compression]"
+        ) from None
+
+
 class CompressedPayloadData(BaseModel):
     compression: AlgorithmConfig
-    b64payload: str
+    payload: bytes
 
     @classmethod
     def from_payload(
         cls, payload: bytes, compression: AlgorithmConfig
     ) -> "CompressedPayloadData":
-        return cls(
-            compression=compression,
-            b64payload=base64.b64encode(payload).decode("utf-8"),
-        )
+        return cls(compression=compression, payload=payload)
 
-    def get_payload(self) -> bytes:
+    @classmethod
+    def from_msgpack(cls, data: bytes) -> "CompressedPayloadData":
+        msgpack = _require_msgpack()
         try:
-            return base64.b64decode(self.b64payload, validate=True)
-        except binascii.Error as exc:
+            unpacked = msgpack.unpackb(data, raw=False)
+        except Exception as exc:
             raise WorkflowPayloadCompressionException(
                 "Invalid compressed payload data"
             ) from exc
+        try:
+            return cls.model_validate(unpacked)
+        except ValidationError as exc:
+            raise WorkflowPayloadCompressionException(
+                "Invalid compressed payload metadata"
+            ) from exc
+
+    def to_msgpack(self) -> bytes:
+        msgpack = _require_msgpack()
+        return msgpack.packb(
+            {
+                "compression": self.compression.model_dump(mode="json"),
+                "payload": self.payload,
+            },
+            use_bin_type=True,
+        )
+
+    def get_payload(self) -> bytes:
+        return self.payload
 
 
 class PayloadEncoder:
@@ -280,15 +306,10 @@ class PayloadEncoder:
         compressed_payload = CompressedPayloadData.from_payload(
             compressed, self.compressor.algorithm_config
         )
-        return compressed_payload.model_dump_json().encode(), True
+        return compressed_payload.to_msgpack(), True
 
     def _decompress(self, data: bytes) -> bytes:
-        try:
-            compressed_payload = CompressedPayloadData.model_validate_json(data)
-        except ValidationError as exc:
-            raise WorkflowPayloadCompressionException(
-                "Invalid compressed payload metadata"
-            ) from exc
+        compressed_payload = CompressedPayloadData.from_msgpack(data)
         return compressor_from_config(compressed_payload.compression).decompress(
             compressed_payload.get_payload()
         )
@@ -359,7 +380,6 @@ class PayloadEncoder:
         self,
         data: bytes,
         encoding_options: List[EncodedPayloadOptions],
-        encoding_metadata: dict[str, object] | None = None,
     ) -> bytes:
         # Decode in the exact reverse order of the encoding_options wire list.
         for option in reversed(encoding_options):
@@ -429,7 +449,6 @@ class PayloadEncoder:
         decrypted_bytes = await self.decode_payload_content(
             encrypted_bytes,
             encoding_options,
-            payload_data.get("encoding_metadata", {}),
         )
         decrypted_value = json.loads(decrypted_bytes)
 
@@ -492,7 +511,6 @@ class PayloadEncoder:
         byte_results = await self.decode_payload_content(
             network_encoded_payload.get_payload(),
             network_encoded_payload.encoding_options,
-            network_encoded_payload.encoding_metadata,
         )
         try:
             return from_json(byte_results)

--- a/src/mistralai/extra/workflows/encoding/payload_encoder.py
+++ b/src/mistralai/extra/workflows/encoding/payload_encoder.py
@@ -32,6 +32,7 @@ from mistralai.extra.workflows.encoding.config import (
     WorkflowEncodingConfig,
 )
 from mistralai.extra.workflows.encoding.payload_compressor import (
+    _require_msgpack,
     build_compressor,
     compressor_from_config,
 )
@@ -55,15 +56,6 @@ logger = logging.getLogger(__name__)
 
 class OffloadedPayloadData(BaseModel):
     key: str
-
-
-def _require_msgpack() -> Any:
-    try:
-        return __import__("msgpack")
-    except ImportError:
-        raise WorkflowPayloadCompressionException(
-            "Payload compression requires installing mistralai[workflow_payload_compression]"
-        ) from None
 
 
 class CompressedPayloadData(BaseModel):

--- a/src/mistralai/extra/workflows/encoding/payload_encoder.py
+++ b/src/mistralai/extra/workflows/encoding/payload_encoder.py
@@ -9,6 +9,7 @@ import os
 import urllib.parse
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
+import msgpack
 from pydantic import BaseModel, ValidationError
 
 if TYPE_CHECKING:
@@ -32,7 +33,6 @@ from mistralai.extra.workflows.encoding.config import (
     WorkflowEncodingConfig,
 )
 from mistralai.extra.workflows.encoding.payload_compressor import (
-    _require_msgpack,
     build_compressor,
     compressor_from_config,
 )
@@ -70,7 +70,6 @@ class CompressedPayloadData(BaseModel):
 
     @classmethod
     def from_msgpack(cls, data: bytes) -> "CompressedPayloadData":
-        msgpack = _require_msgpack()
         try:
             unpacked = msgpack.unpackb(data, raw=False)
         except Exception as exc:
@@ -85,7 +84,6 @@ class CompressedPayloadData(BaseModel):
             ) from exc
 
     def to_msgpack(self) -> bytes:
-        msgpack = _require_msgpack()
         return msgpack.packb(
             {
                 "compression": self.compression.model_dump(mode="json"),

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "2026-05-14T15:39:16.720883852Z"
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "aioboto3"
 version = "12.4.0"
@@ -1058,6 +1062,7 @@ realtime = [
     { name = "websockets" },
 ]
 workflow-payload-compression = [
+    { name = "msgpack" },
     { name = "zstandard" },
 ]
 workflow-payload-encryption = [
@@ -1086,6 +1091,7 @@ dev = [
     { name = "griffe" },
     { name = "invoke" },
     { name = "mcp" },
+    { name = "msgpack" },
     { name = "mypy" },
     { name = "opentelemetry-sdk" },
     { name = "pylint" },
@@ -1121,6 +1127,7 @@ requires-dist = [
     { name = "mistralai", extras = ["workflow-payload-offloading-azure"], marker = "extra == 'workflow-payload-offloading'" },
     { name = "mistralai", extras = ["workflow-payload-offloading-gcs"], marker = "extra == 'workflow-payload-offloading'" },
     { name = "mistralai", extras = ["workflow-payload-offloading-s3"], marker = "extra == 'workflow-payload-offloading'" },
+    { name = "msgpack", marker = "extra == 'workflow-payload-compression'", specifier = ">=1.1.0,<2.0.0" },
     { name = "opentelemetry-api", specifier = ">=1.33.1,<2.0.0" },
     { name = "opentelemetry-semantic-conventions", specifier = ">=0.60b1,<0.61" },
     { name = "pydantic", specifier = ">=2.11.2" },
@@ -1138,6 +1145,7 @@ dev = [
     { name = "griffe", specifier = ">=1.7.3,<2" },
     { name = "invoke", specifier = ">=2.2.0,<3" },
     { name = "mcp", specifier = ">=1.0,<2" },
+    { name = "msgpack", specifier = ">=1.1.0,<2.0.0" },
     { name = "mypy", specifier = "==1.15.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.33.1,<2.0.0" },
     { name = "pylint", specifier = "==3.2.3" },
@@ -1180,6 +1188,67 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/01/99/5d239b6156eddf761a636bded1118414d161bd6b7b37a9335549ed159396/msal_extensions-1.3.1.tar.gz", hash = "sha256:c5b0fd10f65ef62b5f1d62f4251d51cbcaf003fcedae8c91b040a488614be1a4", size = 23315, upload-time = "2025-03-14T23:51:03.902Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/75/bd9b7bb966668920f06b200e84454c8f3566b102183bc55c5473d96cb2b9/msal_extensions-1.3.1-py3-none-any.whl", hash = "sha256:96d3de4d034504e969ac5e85bae8106c8373b5c6568e4c8fa7af2eca9dbe6bca", size = 20583, upload-time = "2025-03-14T23:51:03.016Z" },
+]
+
+[[package]]
+name = "msgpack"
+version = "1.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/f2/bfb55a6236ed8725a96b0aa3acbd0ec17588e6a2c3b62a93eb513ed8783f/msgpack-1.1.2.tar.gz", hash = "sha256:3b60763c1373dd60f398488069bcdc703cd08a711477b5d480eecc9f9626f47e", size = 173581, upload-time = "2025-10-08T09:15:56.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/a2/3b68a9e769db68668b25c6108444a35f9bd163bb848c0650d516761a59c0/msgpack-1.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0051fffef5a37ca2cd16978ae4f0aef92f164df86823871b5162812bebecd8e2", size = 81318, upload-time = "2025-10-08T09:14:38.722Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e1/2b720cc341325c00be44e1ed59e7cfeae2678329fbf5aa68f5bda57fe728/msgpack-1.1.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a605409040f2da88676e9c9e5853b3449ba8011973616189ea5ee55ddbc5bc87", size = 83786, upload-time = "2025-10-08T09:14:40.082Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e5/c2241de64bfceac456b140737812a2ab310b10538a7b34a1d393b748e095/msgpack-1.1.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b696e83c9f1532b4af884045ba7f3aa741a63b2bc22617293a2c6a7c645f251", size = 398240, upload-time = "2025-10-08T09:14:41.151Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/09/2a06956383c0fdebaef5aa9246e2356776f12ea6f2a44bd1368abf0e46c4/msgpack-1.1.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:365c0bbe981a27d8932da71af63ef86acc59ed5c01ad929e09a0b88c6294e28a", size = 406070, upload-time = "2025-10-08T09:14:42.821Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/74/2957703f0e1ef20637d6aead4fbb314330c26f39aa046b348c7edcf6ca6b/msgpack-1.1.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:41d1a5d875680166d3ac5c38573896453bbbea7092936d2e107214daf43b1d4f", size = 393403, upload-time = "2025-10-08T09:14:44.38Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/09/3bfc12aa90f77b37322fc33e7a8a7c29ba7c8edeadfa27664451801b9860/msgpack-1.1.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:354e81bcdebaab427c3df4281187edc765d5d76bfb3a7c125af9da7a27e8458f", size = 398947, upload-time = "2025-10-08T09:14:45.56Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4f/05fcebd3b4977cb3d840f7ef6b77c51f8582086de5e642f3fefee35c86fc/msgpack-1.1.2-cp310-cp310-win32.whl", hash = "sha256:e64c8d2f5e5d5fda7b842f55dec6133260ea8f53c4257d64494c534f306bf7a9", size = 64769, upload-time = "2025-10-08T09:14:47.334Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/3e/b4547e3a34210956382eed1c85935fff7e0f9b98be3106b3745d7dec9c5e/msgpack-1.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:db6192777d943bdaaafb6ba66d44bf65aa0e9c5616fa1d2da9bb08828c6b39aa", size = 71293, upload-time = "2025-10-08T09:14:48.665Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/97/560d11202bcd537abca693fd85d81cebe2107ba17301de42b01ac1677b69/msgpack-1.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2e86a607e558d22985d856948c12a3fa7b42efad264dca8a3ebbcfa2735d786c", size = 82271, upload-time = "2025-10-08T09:14:49.967Z" },
+    { url = "https://files.pythonhosted.org/packages/83/04/28a41024ccbd67467380b6fb440ae916c1e4f25e2cd4c63abe6835ac566e/msgpack-1.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:283ae72fc89da59aa004ba147e8fc2f766647b1251500182fac0350d8af299c0", size = 84914, upload-time = "2025-10-08T09:14:50.958Z" },
+    { url = "https://files.pythonhosted.org/packages/71/46/b817349db6886d79e57a966346cf0902a426375aadc1e8e7a86a75e22f19/msgpack-1.1.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61c8aa3bd513d87c72ed0b37b53dd5c5a0f58f2ff9f26e1555d3bd7948fb7296", size = 416962, upload-time = "2025-10-08T09:14:51.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e0/6cc2e852837cd6086fe7d8406af4294e66827a60a4cf60b86575a4a65ca8/msgpack-1.1.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:454e29e186285d2ebe65be34629fa0e8605202c60fbc7c4c650ccd41870896ef", size = 426183, upload-time = "2025-10-08T09:14:53.477Z" },
+    { url = "https://files.pythonhosted.org/packages/25/98/6a19f030b3d2ea906696cedd1eb251708e50a5891d0978b012cb6107234c/msgpack-1.1.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7bc8813f88417599564fafa59fd6f95be417179f76b40325b500b3c98409757c", size = 411454, upload-time = "2025-10-08T09:14:54.648Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/cd/9098fcb6adb32187a70b7ecaabf6339da50553351558f37600e53a4a2a23/msgpack-1.1.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bafca952dc13907bdfdedfc6a5f579bf4f292bdd506fadb38389afa3ac5b208e", size = 422341, upload-time = "2025-10-08T09:14:56.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/ae/270cecbcf36c1dc85ec086b33a51a4d7d08fc4f404bdbc15b582255d05ff/msgpack-1.1.2-cp311-cp311-win32.whl", hash = "sha256:602b6740e95ffc55bfb078172d279de3773d7b7db1f703b2f1323566b878b90e", size = 64747, upload-time = "2025-10-08T09:14:57.882Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/79/309d0e637f6f37e83c711f547308b91af02b72d2326ddd860b966080ef29/msgpack-1.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:d198d275222dc54244bf3327eb8cbe00307d220241d9cec4d306d49a44e85f68", size = 71633, upload-time = "2025-10-08T09:14:59.177Z" },
+    { url = "https://files.pythonhosted.org/packages/73/4d/7c4e2b3d9b1106cd0aa6cb56cc57c6267f59fa8bfab7d91df5adc802c847/msgpack-1.1.2-cp311-cp311-win_arm64.whl", hash = "sha256:86f8136dfa5c116365a8a651a7d7484b65b13339731dd6faebb9a0242151c406", size = 64755, upload-time = "2025-10-08T09:15:00.48Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/bd/8b0d01c756203fbab65d265859749860682ccd2a59594609aeec3a144efa/msgpack-1.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:70a0dff9d1f8da25179ffcf880e10cf1aad55fdb63cd59c9a49a1b82290062aa", size = 81939, upload-time = "2025-10-08T09:15:01.472Z" },
+    { url = "https://files.pythonhosted.org/packages/34/68/ba4f155f793a74c1483d4bdef136e1023f7bcba557f0db4ef3db3c665cf1/msgpack-1.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:446abdd8b94b55c800ac34b102dffd2f6aa0ce643c55dfc017ad89347db3dbdb", size = 85064, upload-time = "2025-10-08T09:15:03.764Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/60/a064b0345fc36c4c3d2c743c82d9100c40388d77f0b48b2f04d6041dbec1/msgpack-1.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c63eea553c69ab05b6747901b97d620bb2a690633c77f23feb0c6a947a8a7b8f", size = 417131, upload-time = "2025-10-08T09:15:05.136Z" },
+    { url = "https://files.pythonhosted.org/packages/65/92/a5100f7185a800a5d29f8d14041f61475b9de465ffcc0f3b9fba606e4505/msgpack-1.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:372839311ccf6bdaf39b00b61288e0557916c3729529b301c52c2d88842add42", size = 427556, upload-time = "2025-10-08T09:15:06.837Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/87/ffe21d1bf7d9991354ad93949286f643b2bb6ddbeab66373922b44c3b8cc/msgpack-1.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2929af52106ca73fcb28576218476ffbb531a036c2adbcf54a3664de124303e9", size = 404920, upload-time = "2025-10-08T09:15:08.179Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/41/8543ed2b8604f7c0d89ce066f42007faac1eaa7d79a81555f206a5cdb889/msgpack-1.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:be52a8fc79e45b0364210eef5234a7cf8d330836d0a64dfbb878efa903d84620", size = 415013, upload-time = "2025-10-08T09:15:09.83Z" },
+    { url = "https://files.pythonhosted.org/packages/41/0d/2ddfaa8b7e1cee6c490d46cb0a39742b19e2481600a7a0e96537e9c22f43/msgpack-1.1.2-cp312-cp312-win32.whl", hash = "sha256:1fff3d825d7859ac888b0fbda39a42d59193543920eda9d9bea44d958a878029", size = 65096, upload-time = "2025-10-08T09:15:11.11Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/ec/d431eb7941fb55a31dd6ca3404d41fbb52d99172df2e7707754488390910/msgpack-1.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1de460f0403172cff81169a30b9a92b260cb809c4cb7e2fc79ae8d0510c78b6b", size = 72708, upload-time = "2025-10-08T09:15:12.554Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/31/5b1a1f70eb0e87d1678e9624908f86317787b536060641d6798e3cf70ace/msgpack-1.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:be5980f3ee0e6bd44f3a9e9dea01054f175b50c3e6cdb692bc9424c0bbb8bf69", size = 64119, upload-time = "2025-10-08T09:15:13.589Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/31/b46518ecc604d7edf3a4f94cb3bf021fc62aa301f0cb849936968164ef23/msgpack-1.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4efd7b5979ccb539c221a4c4e16aac1a533efc97f3b759bb5a5ac9f6d10383bf", size = 81212, upload-time = "2025-10-08T09:15:14.552Z" },
+    { url = "https://files.pythonhosted.org/packages/92/dc/c385f38f2c2433333345a82926c6bfa5ecfff3ef787201614317b58dd8be/msgpack-1.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:42eefe2c3e2af97ed470eec850facbe1b5ad1d6eacdbadc42ec98e7dcf68b4b7", size = 84315, upload-time = "2025-10-08T09:15:15.543Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/68/93180dce57f684a61a88a45ed13047558ded2be46f03acb8dec6d7c513af/msgpack-1.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1fdf7d83102bf09e7ce3357de96c59b627395352a4024f6e2458501f158bf999", size = 412721, upload-time = "2025-10-08T09:15:16.567Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ba/459f18c16f2b3fc1a1ca871f72f07d70c07bf768ad0a507a698b8052ac58/msgpack-1.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fac4be746328f90caa3cd4bc67e6fe36ca2bf61d5c6eb6d895b6527e3f05071e", size = 424657, upload-time = "2025-10-08T09:15:17.825Z" },
+    { url = "https://files.pythonhosted.org/packages/38/f8/4398c46863b093252fe67368b44edc6c13b17f4e6b0e4929dbf0bdb13f23/msgpack-1.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:fffee09044073e69f2bad787071aeec727183e7580443dfeb8556cbf1978d162", size = 402668, upload-time = "2025-10-08T09:15:19.003Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ce/698c1eff75626e4124b4d78e21cca0b4cc90043afb80a507626ea354ab52/msgpack-1.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5928604de9b032bc17f5099496417f113c45bc6bc21b5c6920caf34b3c428794", size = 419040, upload-time = "2025-10-08T09:15:20.183Z" },
+    { url = "https://files.pythonhosted.org/packages/67/32/f3cd1667028424fa7001d82e10ee35386eea1408b93d399b09fb0aa7875f/msgpack-1.1.2-cp313-cp313-win32.whl", hash = "sha256:a7787d353595c7c7e145e2331abf8b7ff1e6673a6b974ded96e6d4ec09f00c8c", size = 65037, upload-time = "2025-10-08T09:15:21.416Z" },
+    { url = "https://files.pythonhosted.org/packages/74/07/1ed8277f8653c40ebc65985180b007879f6a836c525b3885dcc6448ae6cb/msgpack-1.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:a465f0dceb8e13a487e54c07d04ae3ba131c7c5b95e2612596eafde1dccf64a9", size = 72631, upload-time = "2025-10-08T09:15:22.431Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/db/0314e4e2db56ebcf450f277904ffd84a7988b9e5da8d0d61ab2d057df2b6/msgpack-1.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:e69b39f8c0aa5ec24b57737ebee40be647035158f14ed4b40e6f150077e21a84", size = 64118, upload-time = "2025-10-08T09:15:23.402Z" },
+    { url = "https://files.pythonhosted.org/packages/22/71/201105712d0a2ff07b7873ed3c220292fb2ea5120603c00c4b634bcdafb3/msgpack-1.1.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e23ce8d5f7aa6ea6d2a2b326b4ba46c985dbb204523759984430db7114f8aa00", size = 81127, upload-time = "2025-10-08T09:15:24.408Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/9f/38ff9e57a2eade7bf9dfee5eae17f39fc0e998658050279cbb14d97d36d9/msgpack-1.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6c15b7d74c939ebe620dd8e559384be806204d73b4f9356320632d783d1f7939", size = 84981, upload-time = "2025-10-08T09:15:25.812Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a9/3536e385167b88c2cc8f4424c49e28d49a6fc35206d4a8060f136e71f94c/msgpack-1.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:99e2cb7b9031568a2a5c73aa077180f93dd2e95b4f8d3b8e14a73ae94a9e667e", size = 411885, upload-time = "2025-10-08T09:15:27.22Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/40/dc34d1a8d5f1e51fc64640b62b191684da52ca469da9cd74e84936ffa4a6/msgpack-1.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:180759d89a057eab503cf62eeec0aa61c4ea1200dee709f3a8e9397dbb3b6931", size = 419658, upload-time = "2025-10-08T09:15:28.4Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ef/2b92e286366500a09a67e03496ee8b8ba00562797a52f3c117aa2b29514b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:04fb995247a6e83830b62f0b07bf36540c213f6eac8e851166d8d86d83cbd014", size = 403290, upload-time = "2025-10-08T09:15:29.764Z" },
+    { url = "https://files.pythonhosted.org/packages/78/90/e0ea7990abea5764e4655b8177aa7c63cdfa89945b6e7641055800f6c16b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8e22ab046fa7ede9e36eeb4cfad44d46450f37bb05d5ec482b02868f451c95e2", size = 415234, upload-time = "2025-10-08T09:15:31.022Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4e/9390aed5db983a2310818cd7d3ec0aecad45e1f7007e0cda79c79507bb0d/msgpack-1.1.2-cp314-cp314-win32.whl", hash = "sha256:80a0ff7d4abf5fecb995fcf235d4064b9a9a8a40a3ab80999e6ac1e30b702717", size = 66391, upload-time = "2025-10-08T09:15:32.265Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f1/abd09c2ae91228c5f3998dbd7f41353def9eac64253de3c8105efa2082f7/msgpack-1.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:9ade919fac6a3e7260b7f64cea89df6bec59104987cbea34d34a2fa15d74310b", size = 73787, upload-time = "2025-10-08T09:15:33.219Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/b0/9d9f667ab48b16ad4115c1935d94023b82b3198064cb84a123e97f7466c1/msgpack-1.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:59415c6076b1e30e563eb732e23b994a61c159cec44deaf584e5cc1dd662f2af", size = 66453, upload-time = "2025-10-08T09:15:34.225Z" },
+    { url = "https://files.pythonhosted.org/packages/16/67/93f80545eb1792b61a217fa7f06d5e5cb9e0055bed867f43e2b8e012e137/msgpack-1.1.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:897c478140877e5307760b0ea66e0932738879e7aa68144d9b78ea4c8302a84a", size = 85264, upload-time = "2025-10-08T09:15:35.61Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/33c8a24959cf193966ef11a6f6a2995a65eb066bd681fd085afd519a57ce/msgpack-1.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a668204fa43e6d02f89dbe79a30b0d67238d9ec4c5bd8a940fc3a004a47b721b", size = 89076, upload-time = "2025-10-08T09:15:36.619Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/6b/62e85ff7193663fbea5c0254ef32f0c77134b4059f8da89b958beb7696f3/msgpack-1.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5559d03930d3aa0f3aacb4c42c776af1a2ace2611871c84a75afe436695e6245", size = 435242, upload-time = "2025-10-08T09:15:37.647Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/47/5c74ecb4cc277cf09f64e913947871682ffa82b3b93c8dad68083112f412/msgpack-1.1.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70c5a7a9fea7f036b716191c29047374c10721c389c21e9ffafad04df8c52c90", size = 432509, upload-time = "2025-10-08T09:15:38.794Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a4/e98ccdb56dc4e98c929a3f150de1799831c0a800583cde9fa022fa90602d/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f2cb069d8b981abc72b41aea1c580ce92d57c673ec61af4c500153a626cb9e20", size = 415957, upload-time = "2025-10-08T09:15:40.238Z" },
+    { url = "https://files.pythonhosted.org/packages/da/28/6951f7fb67bc0a4e184a6b38ab71a92d9ba58080b27a77d3e2fb0be5998f/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d62ce1f483f355f61adb5433ebfd8868c5f078d1a52d042b0a998682b4fa8c27", size = 422910, upload-time = "2025-10-08T09:15:41.505Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/03/42106dcded51f0a0b5284d3ce30a671e7bd3f7318d122b2ead66ad289fed/msgpack-1.1.2-cp314-cp314t-win32.whl", hash = "sha256:1d1418482b1ee984625d88aa9585db570180c286d942da463533b238b98b812b", size = 75197, upload-time = "2025-10-08T09:15:42.954Z" },
+    { url = "https://files.pythonhosted.org/packages/15/86/d0071e94987f8db59d4eeb386ddc64d0bb9b10820a8d82bcd3e53eeb2da6/msgpack-1.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:5a46bf7e831d09470ad92dff02b8b1ac92175ca36b087f904a0519857c6be3ff", size = 85772, upload-time = "2025-10-08T09:15:43.954Z" },
+    { url = "https://files.pythonhosted.org/packages/81/f2/08ace4142eb281c12701fc3b93a10795e4d4dc7f753911d836675050f886/msgpack-1.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d99ef64f349d5ec3293688e91486c5fdb925ed03807f64d98d205d2713c60b46", size = 70868, upload-time = "2025-10-08T09:15:44.959Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-14T15:39:16.720883852Z"
+exclude-newer = "2026-05-14T16:51:10.662539415Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -1041,6 +1041,7 @@ dependencies = [
     { name = "eval-type-backport" },
     { name = "httpx" },
     { name = "jsonpath-python" },
+    { name = "msgpack" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "pydantic" },
@@ -1062,7 +1063,6 @@ realtime = [
     { name = "websockets" },
 ]
 workflow-payload-compression = [
-    { name = "msgpack" },
     { name = "zstandard" },
 ]
 workflow-payload-encryption = [
@@ -1091,7 +1091,6 @@ dev = [
     { name = "griffe" },
     { name = "invoke" },
     { name = "mcp" },
-    { name = "msgpack" },
     { name = "mypy" },
     { name = "opentelemetry-sdk" },
     { name = "pylint" },
@@ -1127,7 +1126,7 @@ requires-dist = [
     { name = "mistralai", extras = ["workflow-payload-offloading-azure"], marker = "extra == 'workflow-payload-offloading'" },
     { name = "mistralai", extras = ["workflow-payload-offloading-gcs"], marker = "extra == 'workflow-payload-offloading'" },
     { name = "mistralai", extras = ["workflow-payload-offloading-s3"], marker = "extra == 'workflow-payload-offloading'" },
-    { name = "msgpack", marker = "extra == 'workflow-payload-compression'", specifier = ">=1.1.0,<2.0.0" },
+    { name = "msgpack", specifier = ">=1.1.0,<2.0.0" },
     { name = "opentelemetry-api", specifier = ">=1.33.1,<2.0.0" },
     { name = "opentelemetry-semantic-conventions", specifier = ">=0.60b1,<0.61" },
     { name = "pydantic", specifier = ">=2.11.2" },
@@ -1145,7 +1144,6 @@ dev = [
     { name = "griffe", specifier = ">=1.7.3,<2" },
     { name = "invoke", specifier = ">=2.2.0,<3" },
     { name = "mcp", specifier = ">=1.0,<2" },
-    { name = "msgpack", specifier = ">=1.1.0,<2.0.0" },
     { name = "mypy", specifier = "==1.15.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.33.1,<2.0.0" },
     { name = "pylint", specifier = "==3.2.3" },


### PR DESCRIPTION
## Summary
- Remove workflow payload encoding_metadata and keep compression config in CompressedPayloadData
- Encode compressed payload envelopes with MessagePack instead of JSON/base64
- Add msgpack to workflow payload compression dependencies and mypy config

## Checks
- `uv run mypy src/mistralai/extra/workflows/encoding/payload_encoder.py src/mistralai/extra/workflows/encoding/models.py src/mistralai/extra/tests/test_workflow_encoding.py`
- `uv run ruff check src/mistralai/extra/workflows/encoding/models.py src/mistralai/extra/workflows/encoding/payload_encoder.py src/mistralai/extra/tests/test_workflow_encoding.py`
- `uv run ruff format --check src/mistralai/extra/workflows/encoding/models.py src/mistralai/extra/workflows/encoding/payload_encoder.py src/mistralai/extra/tests/test_workflow_encoding.py`
- `uv run python -m pytest src/mistralai/extra/tests/test_workflow_encoding.py -q`