### PR TITLE
chore: bump speakeasyVersion to 1.763.6

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,5 +1,5 @@
 workflowVersion: 1.0.0
-speakeasyVersion: 1.763.2
+speakeasyVersion: 1.763.6
 sources:
     mistral-azure-source:
         inputs:


### PR DESCRIPTION
## Summary

Bumps the pinned Speakeasy CLI version from 1.763.2 to 1.763.6 in `.speakeasy/workflow.yaml`.

## Why

Picks up two upstream Python generator fixes shipped between 1.763.2 and 1.763.6:

- **envVarPrefix fallback when SDK is constructed without security args** (1.763.4 + 1.763.6). Today `Mistral()` with no args produces `api_key=None` and never reads `MISTRAL_API_KEY` from the environment, which is inconsistent with how OpenAI, Anthropic, Cohere and other SDKs behave. With the fix, the generated `Mistral.__init__` passes `None` through so the existing `get_security_from_env` helper actually fires and reads the env var.
- **Types package support exports preserved correctly** (1.763.4).
- **Multi-SDK fixes** for async declarations, doc rendering, exports (1.763.3).

## Validation

Tested locally:
- `speakeasy run -t mistralai-sdk` at 1.763.6 completes clean (same drift surface as 1.763.2, ~249 files of accumulated spec changes, no conflicts).
- The regenerated `src/mistralai/client/sdk.py` contains the security fallback patch.
- Verified end-to-end: `Mistral()` with only `MISTRAL_API_KEY` set in env correctly resolves the api_key via `get_security_from_env`.

## What this PR does NOT do

Only bumps the pinned version. The actual SDK regeneration with the new generator will happen via the next `Generate MISTRALAI` workflow run, producing the usual regen auto-PR.