### PR TITLE
ci: rename publish env from public-sdk to publish

### DIFF
--- a/.github/workflows/sdk_publish_mistralai_sdk.yaml
+++ b/.github/workflows/sdk_publish_mistralai_sdk.yaml
@@ -23,7 +23,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && github.event.inputs.confirm_publish == 'publish')
     runs-on: ubuntu-24.04
     environment:
-      name: public-sdk
+      name: publish
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
## Summary

The python publish workflow references an environment called `public-sdk` that no longer exists on the repo (verified via API). All other workflows in the repo use `publish` as the env name.

## Fix

One-line rename in `.github/workflows/sdk_publish_mistralai_sdk.yaml`:

```diff
     environment:
-      name: public-sdk
+      name: publish
```

## Why this matters

Without this fix, the publish workflow either fails or skips the required reviewer gate entirely when triggered on push to main, defeating the env-scoping setup.