### PR TITLE
ci: narrow publish trigger to root RELEASES.md only

### DIFF
--- a/.github/workflows/sdk_publish_mistralai_sdk.yaml
+++ b/.github/workflows/sdk_publish_mistralai_sdk.yaml
@@ -13,7 +13,7 @@ permissions:
     branches:
       - main
     paths:
-      - "**/RELEASES.md"
+      - RELEASES.md
 jobs:
   publish:
     name: Publish Python SDKs to PyPI


### PR DESCRIPTION
## Summary

The publish workflow currently triggers on any `**/RELEASES.md` change in main. Since the workflow builds a single bundled `mistralai` wheel from root `pyproject.toml` (with sub-packages as source-included), only the root `RELEASES.md` changing reflects a new release.

Sub-package `RELEASES.md` changes (`packages/azure`, `packages/gcp`) shouldn't trigger publish runs since they don't produce a new bundled wheel.

## Fix

\`\`\`diff
   push:
     branches:
       - main
     paths:
-      - \"**/RELEASES.md\"
+      - RELEASES.md
\`\`\`

## Effect

- Azure/gcp regen merges no longer trigger spurious publish workflow runs that wait at the env gate
- Only meaningful releases (root RELEASES.md bump) trigger publish