### PR TITLE
ci: remove standalone azure and gcp PyPI publish steps

### DIFF
--- a/.github/workflows/sdk_publish_mistralai_sdk.yaml
+++ b/.github/workflows/sdk_publish_mistralai_sdk.yaml
@@ -48,31 +48,3 @@ jobs:
           print-hash: true
           verbose: true
           skip-existing: true
-
-      - name: Build mistralai-azure
-        working-directory: packages/azure
-        run: |
-          python scripts/prepare_readme.py
-          uv build --sdist --wheel --out-dir ../../dist/mistralai-azure
-
-      - name: Publish mistralai-azure to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13
-        with:
-          packages-dir: dist/mistralai-azure/
-          print-hash: true
-          verbose: true
-          skip-existing: true
-
-      - name: Build mistralai-gcp
-        working-directory: packages/gcp
-        run: |
-          python scripts/prepare_readme.py
-          uv build --sdist --wheel --out-dir ../../dist/mistralai-gcp
-
-      - name: Publish mistralai-gcp to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13
-        with:
-          packages-dir: dist/mistralai-gcp/
-          print-hash: true
-          verbose: true
-          skip-existing: true


### PR DESCRIPTION
## Summary

The Python release model publishes a single `mistralai` package to PyPI. That root wheel already bundles the Azure and GCP clients, so the workflow should not attempt to publish `mistralai-azure` or `mistralai-gcp` as standalone PyPI projects.

## Fix

Remove the standalone Azure and GCP build/publish steps from `sdk_publish_mistralai_sdk.yaml`, leaving only the bundled `mistralai` publish path.

## Why

Keeping the extra publish steps makes the workflow fail after the real package has already been published, which creates noise and does not match how the package is meant to ship.
