### PR TITLE
Fix OTEL parenting for HTTPX spans

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ dev = [
     "pyyaml>=6.0.2,<7",
     "mypy==1.15.0",
     "msgpack>=1.1.0,<2.0.0",
+    "opentelemetry-instrumentation-httpx (>=0.60b1,<0.61)",
     "opentelemetry-sdk (>=1.33.1,<2.0.0)",
     "opentelemetry-exporter-otlp-proto-http (>=1.33.1,<2.0.0)",
     "pylint==3.2.3",

--- a/src/mistralai/client/_hooks/tracing.py
+++ b/src/mistralai/client/_hooks/tracing.py
@@ -49,6 +49,10 @@ class TracingHook(BeforeRequestHook, AfterSuccessHook, AfterErrorHook):
     def before_request(
         self, hook_ctx: BeforeRequestContext, request: httpx.Request
     ) -> Union[httpx.Request, Exception]:
+        # The GenAI span is created in this hook, but HTTPX creates its own
+        # auto-instrumented span later inside send(). Wrap the configured
+        # clients so each request's stored GenAI span is current only while
+        # that request is being sent.
         self._ensure_client_send_wrapped(getattr(hook_ctx.config, "client", None))
         self._ensure_async_client_send_wrapped(
             getattr(hook_ctx.config, "async_client", None)

--- a/src/mistralai/client/_hooks/tracing.py
+++ b/src/mistralai/client/_hooks/tracing.py
@@ -1,12 +1,17 @@
 import logging
+import threading
 import weakref
+from functools import wraps
 from typing import Any, Optional, Tuple, Union
 
 import httpx
+from opentelemetry import context as context_api
 from opentelemetry import trace
-from opentelemetry.trace import Span
+from opentelemetry.trace import Span, Status, StatusCode, set_span_in_context
 
 from mistralai.extra.observability.otel import (
+    TracedResponse,
+    end_span,
     get_or_create_otel_tracer,
     get_response_and_error,
     get_traced_request_and_span,
@@ -26,6 +31,11 @@ logger = logging.getLogger(__name__)
 
 
 _SPAN_EXT_KEY = "_tracing_span"
+_SPAN_CONTEXT_EXT_KEY = "_tracing_span_context"
+_SPAN_FINISHED_EXT_KEY = "_tracing_span_finished"
+_SYNC_SEND_WRAPPED_ATTR = "_mistral_tracing_sync_send_wrapped"
+_ASYNC_SEND_WRAPPED_ATTR = "_mistral_tracing_async_send_wrapped"
+_WRAP_LOCK = threading.Lock()
 
 
 class TracingHook(BeforeRequestHook, AfterSuccessHook, AfterErrorHook):
@@ -39,6 +49,10 @@ class TracingHook(BeforeRequestHook, AfterSuccessHook, AfterErrorHook):
     def before_request(
         self, hook_ctx: BeforeRequestContext, request: httpx.Request
     ) -> Union[httpx.Request, Exception]:
+        self._ensure_client_send_wrapped(getattr(hook_ctx.config, "client", None))
+        self._ensure_async_client_send_wrapped(
+            getattr(hook_ctx.config, "async_client", None)
+        )
         configure_telemetry_for_hook(
             self,
             hook_ctx.config,
@@ -56,15 +70,135 @@ class TracingHook(BeforeRequestHook, AfterSuccessHook, AfterErrorHook):
             operation_id=hook_ctx.operation_id,
             request=request,
         )
-        request.extensions[_SPAN_EXT_KEY] = span
+        self._store_span_on_request(request, span)
         return request
 
     @staticmethod
     def _get_span(response: Optional[httpx.Response]) -> Optional[Span]:
         try:
-            return response.request.extensions.get(_SPAN_EXT_KEY) if response is not None else None
+            if response is None:
+                return None
+            return response.request.extensions.get(_SPAN_EXT_KEY)
         except RuntimeError:
             return None
+
+    @staticmethod
+    def _store_span_on_request(request: httpx.Request, span: Optional[Span]) -> None:
+        request.extensions[_SPAN_EXT_KEY] = span
+        request.extensions[_SPAN_FINISHED_EXT_KEY] = False
+        if span:
+            request.extensions[_SPAN_CONTEXT_EXT_KEY] = set_span_in_context(span)
+            return
+        request.extensions.pop(_SPAN_CONTEXT_EXT_KEY, None)
+
+    @staticmethod
+    def _get_request_span(request: httpx.Request) -> Optional[Span]:
+        try:
+            return request.extensions.get(_SPAN_EXT_KEY)
+        except RuntimeError:
+            return None
+
+    @staticmethod
+    def _mark_span_finished(request: httpx.Request) -> None:
+        try:
+            request.extensions[_SPAN_FINISHED_EXT_KEY] = True
+            request.extensions[_SPAN_EXT_KEY] = None
+        except RuntimeError:
+            return
+
+    @staticmethod
+    def _attach_request_span_context(request: httpx.Request):
+        try:
+            span_context = request.extensions.get(_SPAN_CONTEXT_EXT_KEY)
+        except RuntimeError:
+            return None
+        if span_context is None:
+            return None
+        return context_api.attach(span_context)
+
+    @staticmethod
+    def _detach_request_span_context(token) -> None:
+        if token is not None:
+            context_api.detach(token)
+
+    @classmethod
+    def _finish_request_span_with_error(
+        cls, request: httpx.Request, error: Exception
+    ) -> None:
+        try:
+            if request.extensions.get(_SPAN_FINISHED_EXT_KEY):
+                return
+        except RuntimeError:
+            return
+
+        span = cls._get_request_span(request)
+        if not span:
+            return
+
+        try:
+            span.record_exception(error)
+            span.set_status(Status(StatusCode.ERROR, str(error)))
+        finally:
+            end_span(span)
+            cls._mark_span_finished(request)
+
+    @classmethod
+    def _ensure_client_send_wrapped(cls, client: Any) -> None:
+        if client is None or getattr(client, _SYNC_SEND_WRAPPED_ATTR, False):
+            return
+
+        with _WRAP_LOCK:
+            if getattr(client, _SYNC_SEND_WRAPPED_ATTR, False):
+                return
+
+            original_send = client.send
+
+            @wraps(original_send)
+            def traced_send(request: httpx.Request, *args, **kwargs):
+                token = cls._attach_request_span_context(request)
+                try:
+                    return original_send(request, *args, **kwargs)
+                except Exception as exc:
+                    cls._finish_request_span_with_error(request, exc)
+                    raise
+                finally:
+                    cls._detach_request_span_context(token)
+
+            try:
+                client.send = traced_send
+                setattr(client, _SYNC_SEND_WRAPPED_ATTR, True)
+            except Exception:
+                logger.debug("Failed to wrap sync HTTP client for tracing.")
+
+    @classmethod
+    def _ensure_async_client_send_wrapped(cls, async_client: Any) -> None:
+        if async_client is None or getattr(
+            async_client, _ASYNC_SEND_WRAPPED_ATTR, False
+        ):
+            return
+
+        with _WRAP_LOCK:
+            if getattr(async_client, _ASYNC_SEND_WRAPPED_ATTR, False):
+                return
+
+            original_send = async_client.send
+
+            @wraps(original_send)
+            async def traced_send(request: httpx.Request, *args, **kwargs):
+                token = cls._attach_request_span_context(request)
+                try:
+                    return await original_send(request, *args, **kwargs)
+                except Exception as exc:
+                    cls._finish_request_span_with_error(request, exc)
+                    raise
+                finally:
+                    cls._detach_request_span_context(token)
+
+            try:
+                async_client.send = traced_send
+                setattr(async_client, _ASYNC_SEND_WRAPPED_ATTR, True)
+            except Exception:
+                logger.debug("Failed to wrap async HTTP client for tracing.")
 
     def after_success(
         self, hook_ctx: AfterSuccessContext, response: httpx.Response
@@ -77,6 +211,8 @@ class TracingHook(BeforeRequestHook, AfterSuccessHook, AfterErrorHook):
             operation_id=hook_ctx.operation_id,
             response=response,
         )
+        if span and not isinstance(response, TracedResponse):
+            self._mark_span_finished(response.request)
         return response
 
     def after_error(
@@ -95,4 +231,6 @@ class TracingHook(BeforeRequestHook, AfterSuccessHook, AfterErrorHook):
                 response=response,
                 error=error,
             )
+            if span and response:
+                self._mark_span_finished(response.request)
         return response, error

--- a/src/mistralai/extra/tests/test_otel_tracing.py
+++ b/src/mistralai/extra/tests/test_otel_tracing.py
@@ -12,7 +12,10 @@ Fixtures are defined inline using SDK model classes so each test is self-contain
 # pyright: reportArgumentType=false
 
 import asyncio
+from collections import Counter
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
+import threading
 import unittest
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
@@ -21,6 +24,7 @@ import httpx
 from opentelemetry import context as context_api
 from opentelemetry import trace
 from opentelemetry.baggage import set_baggage
+from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
@@ -142,9 +146,101 @@ def _make_streaming_httpx_response(sse_body: bytes) -> httpx.Response:
     )
 
 
+class _ChatCompletionTestServer:
+    def __init__(self, *, block_until_two_requests: bool = False) -> None:
+        self.block_until_two_requests = block_until_two_requests
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+        self._arrived = 0
+        self._lock = threading.Lock()
+        self._gate = threading.Event()
+
+    def _wait_for_second_request_if_needed(self) -> None:
+        if not self.block_until_two_requests:
+            return
+
+        with self._lock:
+            self._arrived += 1
+            arrived = self._arrived
+        if arrived < 2:
+            self._gate.wait(timeout=5)
+        else:
+            self._gate.set()
+
+    @staticmethod
+    def _response_body(model: str) -> bytes:
+        response = _dump(
+            ChatCompletionResponse(
+                id=f"cmpl-{model}",
+                object="chat.completion",
+                model=model,
+                created=1700000000,
+                choices=[
+                    ChatCompletionChoice(
+                        index=0,
+                        message=AssistantMessage(content=f"ok from {model}"),
+                        finish_reason="stop",
+                    )
+                ],
+                usage=UsageInfo(
+                    prompt_tokens=5,
+                    completion_tokens=2,
+                    total_tokens=7,
+                ),
+            )
+        )
+        return json.dumps(response).encode()
+
+    def __enter__(self):
+        owner = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                content_length = int(self.headers["content-length"])
+                request_body = json.loads(self.rfile.read(content_length))
+                owner._wait_for_second_request_if_needed()
+                data = owner._response_body(request_body["model"])
+                self.send_response(200)
+                self.send_header("content-type", "application/json")
+                self.send_header("content-length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+
+            def log_message(self, format, *args):
+                return
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+
+    @property
+    def url(self) -> str:
+        assert self._server is not None
+        host, port = self._server.server_address
+        return f"http://{host}:{port}"
+
+
 def _parse_json_list(span_attr):
     """Parse a span attribute containing a JSON-encoded array string."""
     return json.loads(span_attr)
+
+
+def _run_async_for_unittest(awaitable):
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        return loop.run_until_complete(awaitable)
+    finally:
+        loop.close()
+        asyncio.set_event_loop(asyncio.new_event_loop())
 
 
 # -- Tests ---------------------------------------------------------------------
@@ -1709,6 +1805,97 @@ class TestOtelTracing(unittest.TestCase):
             ),
             "mistral-small-latest",
         )
+
+    # -- HTTPX auto-instrumentation parenting ---------------------------------
+
+    def test_httpx_auto_instrumented_span_is_child_of_genai_span(self):
+        instrumentor = HTTPXClientInstrumentor()
+        instrumentor.instrument()
+        tracer = trace.get_tracer("test-workflow-parenting")
+
+        try:
+            with _ChatCompletionTestServer() as server, httpx.Client() as http_client:
+                client = Mistral(
+                    api_key="test-key",
+                    client=http_client,
+                    server_url=server.url,
+                )
+                with tracer.start_as_current_span(
+                    "ExecuteActivity:generate_site_diagnostic"
+                ) as activity_span:
+                    client.chat.complete(
+                        model="mistral-small-latest",
+                        messages=[{"role": "user", "content": "hello"}],
+                    )
+
+                    self.assertEqual(
+                        trace.get_current_span().get_span_context().span_id,
+                        activity_span.get_span_context().span_id,
+                    )
+        finally:
+            instrumentor.uninstrument()
+
+        spans = self._get_finished_spans()
+        activity = next(
+            s for s in spans if s.name == "ExecuteActivity:generate_site_diagnostic"
+        )
+        genai = next(s for s in spans if s.name == "chat mistral-small-latest")
+        post = next(s for s in spans if s.name == "POST")
+
+        self.assertEqual(genai.parent.span_id, activity.context.span_id)
+        self.assertEqual(post.parent.span_id, genai.context.span_id)
+
+    def test_concurrent_async_httpx_auto_instrumented_spans_are_genai_children(
+        self,
+    ):
+        instrumentor = HTTPXClientInstrumentor()
+        instrumentor.instrument()
+        tracer = trace.get_tracer("test-workflow-parenting")
+
+        async def _run(server_url: str):
+            async with httpx.AsyncClient() as async_client:
+                client = Mistral(
+                    api_key="test-key",
+                    async_client=async_client,
+                    server_url=server_url,
+                )
+
+                with tracer.start_as_current_span(
+                    "ExecuteActivity:generate_site_diagnostic"
+                ):
+                    return await asyncio.gather(
+                        client.chat.complete_async(
+                            model="mistral-large-latest",
+                            messages=[{"role": "user", "content": "A"}],
+                        ),
+                        client.chat.complete_async(
+                            model="mistral-small-latest",
+                            messages=[{"role": "user", "content": "B"}],
+                        ),
+                    )
+
+        try:
+            with _ChatCompletionTestServer(block_until_two_requests=True) as server:
+                results = _run_async_for_unittest(_run(server.url))
+                self.assertEqual(len(results), 2)
+        finally:
+            instrumentor.uninstrument()
+
+        spans = self._get_finished_spans()
+        activity = next(
+            s for s in spans if s.name == "ExecuteActivity:generate_site_diagnostic"
+        )
+        genai_spans = [s for s in spans if s.name.startswith("chat mistral-")]
+        post_spans = [s for s in spans if s.name == "POST"]
+
+        self.assertEqual(len(genai_spans), 2)
+        self.assertEqual(len(post_spans), 2)
+        for span in genai_spans:
+            self.assertEqual(span.parent.span_id, activity.context.span_id)
+
+        post_parent_counts = Counter(span.parent.span_id for span in post_spans)
+        for span in genai_spans:
+            self.assertEqual(post_parent_counts[span.context.span_id], 1)
 
 
 class TestPerInstanceTracerProvider(unittest.TestCase):

--- a/src/mistralai/extra/tests/test_otel_tracing.py
+++ b/src/mistralai/extra/tests/test_otel_tracing.py
@@ -239,16 +239,6 @@ def _parse_json_list(span_attr):
     return json.loads(span_attr)
 
 
-def _run_async_for_unittest(awaitable):
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    try:
-        return loop.run_until_complete(awaitable)
-    finally:
-        loop.close()
-        asyncio.set_event_loop(asyncio.new_event_loop())
-
-
 # -- Tests ---------------------------------------------------------------------
 
 
@@ -1777,7 +1767,7 @@ class TestOtelTracing(unittest.TestCase):
                 ),
             )
 
-        results = asyncio.get_event_loop().run_until_complete(_run())
+        results = asyncio.run(_run())
 
         # Both calls must succeed
         self.assertEqual(len(results), 2)
@@ -1851,6 +1841,52 @@ class TestOtelTracing(unittest.TestCase):
         self.assertEqual(genai.parent.span_id, activity.context.span_id)
         self.assertEqual(post.parent.span_id, genai.context.span_id)
 
+    def test_httpx_send_error_ends_genai_span_and_restores_parent_context(self):
+        instrumentor = HTTPXClientInstrumentor()
+        instrumentor.instrument()
+        tracer = trace.get_tracer("test-workflow-parenting")
+
+        def raise_connect_error(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("connection failed", request=request)
+
+        try:
+            with httpx.Client(
+                transport=httpx.MockTransport(raise_connect_error)
+            ) as http_client:
+                client = Mistral(
+                    api_key="test-key",
+                    client=http_client,
+                    server_url="https://api.mistral.ai",
+                )
+                with tracer.start_as_current_span(
+                    "ExecuteActivity:generate_site_diagnostic"
+                ) as activity_span:
+                    with self.assertRaises(httpx.ConnectError):
+                        client.chat.complete(
+                            model="mistral-small-latest",
+                            messages=_make_user_messages("hello"),
+                        )
+
+                    self.assertEqual(
+                        trace.get_current_span().get_span_context().span_id,
+                        activity_span.get_span_context().span_id,
+                    )
+        finally:
+            instrumentor.uninstrument()
+
+        spans = self._get_finished_spans()
+        activity = next(
+            s for s in spans if s.name == "ExecuteActivity:generate_site_diagnostic"
+        )
+        genai = next(s for s in spans if s.name == "chat mistral-small-latest")
+        post_spans = [s for s in spans if s.name == "POST"]
+
+        self.assertEqual(genai.parent.span_id, activity.context.span_id)
+        self.assertEqual(genai.status.status_code, StatusCode.ERROR)
+        self.assertIn("connection failed", genai.status.description or "")
+        for post_span in post_spans:
+            self.assertEqual(post_span.parent.span_id, genai.context.span_id)
+
     def test_concurrent_async_httpx_auto_instrumented_spans_are_genai_children(
         self,
     ):
@@ -1882,7 +1918,7 @@ class TestOtelTracing(unittest.TestCase):
 
         try:
             with _ChatCompletionTestServer(block_until_two_requests=True) as server:
-                results = _run_async_for_unittest(_run(server.url))
+                results = asyncio.run(_run(server.url))
                 self.assertEqual(len(results), 2)
         finally:
             instrumentor.uninstrument()

--- a/src/mistralai/extra/tests/test_otel_tracing.py
+++ b/src/mistralai/extra/tests/test_otel_tracing.py
@@ -18,6 +18,7 @@ import json
 import threading
 import unittest
 from datetime import datetime, timezone
+from typing import cast
 from unittest.mock import MagicMock
 
 import httpx
@@ -43,6 +44,7 @@ from mistralai.client.models import (
     AssistantMessage,
     ChatCompletionChoice,
     ChatCompletionRequest,
+    ChatCompletionRequestMessage,
     ChatCompletionResponse,
     CompletionChunk,
     CompletionEvent,
@@ -146,6 +148,10 @@ def _make_streaming_httpx_response(sse_body: bytes) -> httpx.Response:
     )
 
 
+def _make_user_messages(content: str) -> list[ChatCompletionRequestMessage]:
+    return [cast(ChatCompletionRequestMessage, UserMessage(content=content))]
+
+
 class _ChatCompletionTestServer:
     def __init__(self, *, block_until_two_requests: bool = False) -> None:
         self.block_until_two_requests = block_until_two_requests
@@ -224,7 +230,7 @@ class _ChatCompletionTestServer:
     @property
     def url(self) -> str:
         assert self._server is not None
-        host, port = self._server.server_address
+        host, port = cast(tuple[str, int], self._server.server_address)
         return f"http://{host}:{port}"
 
 
@@ -1825,7 +1831,7 @@ class TestOtelTracing(unittest.TestCase):
                 ) as activity_span:
                     client.chat.complete(
                         model="mistral-small-latest",
-                        messages=[{"role": "user", "content": "hello"}],
+                        messages=_make_user_messages("hello"),
                     )
 
                     self.assertEqual(
@@ -1866,11 +1872,11 @@ class TestOtelTracing(unittest.TestCase):
                     return await asyncio.gather(
                         client.chat.complete_async(
                             model="mistral-large-latest",
-                            messages=[{"role": "user", "content": "A"}],
+                            messages=_make_user_messages("A"),
                         ),
                         client.chat.complete_async(
                             model="mistral-small-latest",
-                            messages=[{"role": "user", "content": "B"}],
+                            messages=_make_user_messages("B"),
                         ),
                     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -1110,6 +1110,7 @@ dev = [
     { name = "msgpack" },
     { name = "mypy" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation-httpx" },
     { name = "opentelemetry-sdk" },
     { name = "pylint" },
     { name = "pytest" },
@@ -1167,6 +1168,7 @@ dev = [
     { name = "msgpack", specifier = ">=1.1.0,<2.0.0" },
     { name = "mypy", specifier = "==1.15.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.33.1,<2.0.0" },
+    { name = "opentelemetry-instrumentation-httpx", specifier = ">=0.60b1,<0.61" },
     { name = "opentelemetry-sdk", specifier = ">=1.33.1,<2.0.0" },
     { name = "pylint", specifier = "==3.2.3" },
     { name = "pytest", specifier = ">=8.2.2,<9" },
@@ -1509,6 +1511,37 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-instrumentation"
+version = "0.60b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/0f/7e6b713ac117c1f5e4e3300748af699b9902a2e5e34c9cf443dde25a01fa/opentelemetry_instrumentation-0.60b1.tar.gz", hash = "sha256:57ddc7974c6eb35865af0426d1a17132b88b2ed8586897fee187fd5b8944bd6a", size = 31706, upload-time = "2025-12-11T13:36:42.515Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/d2/6788e83c5c86a2690101681aeef27eeb2a6bf22df52d3f263a22cee20915/opentelemetry_instrumentation-0.60b1-py3-none-any.whl", hash = "sha256:04480db952b48fb1ed0073f822f0ee26012b7be7c3eac1a3793122737c78632d", size = 33096, upload-time = "2025-12-11T13:35:33.067Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-httpx"
+version = "0.60b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/08/11208bcfcab4fc2023252c3f322aa397fd9ad948355fea60f5fc98648603/opentelemetry_instrumentation_httpx-0.60b1.tar.gz", hash = "sha256:a506ebaf28c60112cbe70ad4f0338f8603f148938cb7b6794ce1051cd2b270ae", size = 20611, upload-time = "2025-12-11T13:37:01.661Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/59/b98e84eebf745ffc75397eaad4763795bff8a30cbf2373a50ed4e70646c5/opentelemetry_instrumentation_httpx-0.60b1-py3-none-any.whl", hash = "sha256:f37636dd742ad2af83d896ba69601ed28da51fa4e25d1ab62fde89ce413e275b", size = 15701, upload-time = "2025-12-11T13:36:04.56Z" },
+]
+
+[[package]]
 name = "opentelemetry-proto"
 version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1545,6 +1578,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/91/df/553f93ed38bf22f4b999d9be9c185adb558982214f33eae539d3b5cd0858/opentelemetry_semantic_conventions-0.60b1.tar.gz", hash = "sha256:87c228b5a0669b748c76d76df6c364c369c28f1c465e50f661e39737e84bc953", size = 137935, upload-time = "2025-12-11T13:32:50.487Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/5e/5958555e09635d09b75de3c4f8b9cae7335ca545d77392ffe7331534c402/opentelemetry_semantic_conventions-0.60b1-py3-none-any.whl", hash = "sha256:9fa8c8b0c110da289809292b0591220d3a7b53c1526a23021e977d68597893fb", size = 219982, upload-time = "2025-12-11T13:32:36.955Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-http"
+version = "0.60b1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/fc/c47bb04a1d8a941a4061307e1eddfa331ed4d0ab13d8a9781e6db256940a/opentelemetry_util_http-0.60b1.tar.gz", hash = "sha256:0d97152ca8c8a41ced7172d29d3622a219317f74ae6bb3027cfbdcf22c3cc0d6", size = 11053, upload-time = "2025-12-11T13:37:25.115Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/5c/d3f1733665f7cd582ef0842fb1d2ed0bc1fba10875160593342d22bba375/opentelemetry_util_http-0.60b1-py3-none-any.whl", hash = "sha256:66381ba28550c91bee14dcba8979ace443444af1ed609226634596b4b0faf199", size = 8947, upload-time = "2025-12-11T13:36:37.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- attach the GenAI span context around sync and async HTTP sends so HTTPX auto-instrumented spans parent under the GenAI span
- preserve explicit trace header injection and guard span finalization paths
- add sync and concurrent async regression tests using HTTPX auto-instrumentation

## Tests

I've used this script to visualize what happens in main vs this branch: [otel_httpx_parenting_manual.py](https://github.com/user-attachments/files/28365723/otel_httpx_parenting_manual.py)

```sh
$ MISTRAL_API_KEY=... uv run python otel_httpx_parenting_manual.py

trace tree
- chat mistral-small-latest trace_id=7fdce88146c52658dffab583fd3aedf1 span_id=3b497ca60ee41e5d
  - POST trace_id=7fdce88146c52658dffab583fd3aedf1 span_id=de71956fdb451b92
```

vs main:
```sh
$ MISTRAL_API_KEY=... uv run python otel_httpx_parenting_manual.py
trace tree
- POST trace_id=7b19f66b4437629c0a19f241f78afdeb span_id=db17cc4d3008908b
- chat mistral-small-latest trace_id=d4c48952fb559856d292b2d41ba39d33 span_id=43fdcb003423cb38
```