### PR TITLE
clean: add if __name__ == "__main__" in prepare_readme.py tto avoid modifications to README-PYPI.md when collecting tests

### DIFF
--- a/scripts/prepare_readme.py
+++ b/scripts/prepare_readme.py
@@ -31,21 +31,27 @@ def _rewrite_relative_links(contents: str, base_url: str) -> str:
     )
 
 
-try:
-    with open("README.md", "r", encoding="utf-8") as fh:
-        readme_contents = fh.read()
-
-    base_url = _build_base_url(GITHUB_URL, BRANCH, REPO_SUBDIR)
-    readme_contents = _rewrite_relative_links(readme_contents, base_url)
-
-    with open("README-PYPI.md", "w", encoding="utf-8") as fh:
-        fh.write(readme_contents)
-except Exception as e:
+def main() -> int:
     try:
-        print("Failed to rewrite README.md to README-PYPI.md, copying original instead")
-        print(e)
-        shutil.copyfile("README.md", "README-PYPI.md")
-    except Exception as ie:
-        print("Failed to copy README.md to README-PYPI.md")
-        print(ie)
-        sys.exit(1)
+        with open("README.md", "r", encoding="utf-8") as fh:
+            readme_contents = fh.read()
+
+        base_url = _build_base_url(GITHUB_URL, BRANCH, REPO_SUBDIR)
+        readme_contents = _rewrite_relative_links(readme_contents, base_url)
+
+        with open("README-PYPI.md", "w", encoding="utf-8") as fh:
+            fh.write(readme_contents)
+    except Exception as e:
+        try:
+            print("Failed to rewrite README.md to README-PYPI.md, copying original instead")
+            print(e)
+            shutil.copyfile("README.md", "README-PYPI.md")
+        except Exception as ie:
+            print("Failed to copy README.md to README-PYPI.md")
+            print(ie)
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

`README-PYPI.md` kept showing up as an unstaged change in local working trees even when no one touched the repo.

Root cause: `scripts/prepare_readme.py` has no `if __name__ == "__main__":` guard, so its top-level body — which writes `README-PYPI.md` from `README.md` — runs at **import** time. `tests/test_prepare_readme.py` imports the script via `spec.loader.exec_module(...)`, and VS Code's Python extension auto-runs `pytest --collect-only` on workspace open and on save, silently regenerating `README-PYPI.md` each time.

## Change

Wrap the side-effecting code in `main()` behind the standard `__main__` guard. Direct invocation (`python scripts/prepare_readme.py`, used by `scripts/publish.sh` and the publish workflow) is unchanged; importing it is now a no-op.