### PR TITLE
clean: remove unexisting aio extra of azure-identity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ telemetry = [
 
 workflow_payload_offloading_azure = [
     "azure-storage-blob[aio]>=12.28.0,<13.0.0",
-    "azure-identity[aio]>=1.25.0,<2.0.0",
+    "azure-identity>=1.25.0,<2.0.0",
 ]
 workflow_payload_offloading_gcs = [
     "gcloud-aio-storage>=9.3.0,<10.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [options]
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P7D"
+exclude-newer-span = "P2D"
 
 [[package]]
 name = "aioboto3"
@@ -666,7 +666,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1132,7 +1132,7 @@ lint = [
 requires-dist = [
     { name = "aioboto3", marker = "extra == 'workflow-payload-offloading-s3'", specifier = ">=12.4.0,<13.0.0" },
     { name = "authlib", marker = "extra == 'agents'", specifier = ">=1.5.2,<2.0" },
-    { name = "azure-identity", extras = ["aio"], marker = "extra == 'workflow-payload-offloading-azure'", specifier = ">=1.25.0,<2.0.0" },
+    { name = "azure-identity", marker = "extra == 'workflow-payload-offloading-azure'", specifier = ">=1.25.0,<2.0.0" },
     { name = "azure-storage-blob", extras = ["aio"], marker = "extra == 'workflow-payload-offloading-azure'", specifier = ">=12.28.0,<13.0.0" },
     { name = "cryptography", marker = "extra == 'workflow-payload-encryption'", specifier = ">=41.0.0,<47.0.0" },
     { name = "eval-type-backport", specifier = ">=0.2.0" },


### PR DESCRIPTION
This PR is here to remove the not existing `aio` extra of `azure-identity`.

Running `uv lock` before that change displayed the following warning:

```bash
$ uv lock
...
warning: The package `azure-identity==1.25.3` does not have an extra named `aio`
```