### PR TITLE
fix: keep generated SDK version files aligned

### DIFF
--- a/.github/workflows/sdk_generation_mistralai_sdk.yaml
+++ b/.github/workflows/sdk_generation_mistralai_sdk.yaml
@@ -117,23 +117,39 @@ jobs:
 
           CURRENT=$(grep '^version = ' pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
           if [ "$CURRENT" = "$VERSION" ]; then
-            echo "Version already aligned to $VERSION"
-            exit 0
+            echo "pyproject.toml already aligned to $VERSION"
+          else
+            echo "Updating version from $CURRENT to $VERSION"
+            uv version "$VERSION"
           fi
 
-          echo "Updating version from $CURRENT to $VERSION"
-          uv version "$VERSION"
+          VERSION="$VERSION" python - <<'PY'
+          import os
+          import re
+          from pathlib import Path
+
+          version = os.environ["VERSION"]
+          path = Path("src/mistralai/client/_version.py")
+          text = path.read_text()
+          text = re.sub(r'__version__: str = "[^"]+"', f'__version__: str = "{version}"', text)
+          text = re.sub(
+              r'__user_agent__: str = "speakeasy-sdk/python [^ ]+ ',
+              f'__user_agent__: str = "speakeasy-sdk/python {version} ',
+              text,
+          )
+          path.write_text(text)
+          PY
 
       - name: Commit and push
         if: steps.branch-exists.outputs.exists == 'true'
         run: |
           git config user.email "action@github.com"
           git config user.name "GitHub Action"
-          git add pyproject.toml uv.lock
+          git add pyproject.toml uv.lock src/mistralai/client/_version.py
           if git diff --cached --quiet; then
             echo "No changes to commit"
           else
             VERSION=$(grep '^version = ' pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
-            git commit -m "chore: align pyproject.toml and uv.lock to version $VERSION"
+            git commit -m "chore: align package version files to version $VERSION"
             git push
           fi

--- a/src/mistralai/client/_version.py
+++ b/src/mistralai/client/_version.py
@@ -4,10 +4,10 @@
 import importlib.metadata
 
 __title__: str = "mistralai"
-__version__: str = "2.5.0"
+__version__: str = "2.5.1"
 __openapi_doc_version__: str = "1.0.0"
 __gen_version__: str = "2.884.13"
-__user_agent__: str = "speakeasy-sdk/python 2.5.0 2.884.13 1.0.0 mistralai"
+__user_agent__: str = "speakeasy-sdk/python 2.5.1 2.884.13 1.0.0 mistralai"
 
 try:
     if __package__ is not None:


### PR DESCRIPTION
## Summary

This fixes the stale generated SDK version state that blocks the next Speakeasy Python SDK generation.

`client-python#580` updated `pyproject.toml` and `.speakeasy/gen.lock` to `2.5.1`, but `src/mistralai/client/_version.py` stayed at `2.5.0`. That left the repository inconsistent:

```text
pyproject.toml: 2.5.1
.speakeasy/gen.lock releaseVersion: 2.5.1
src/mistralai/client/_version.py: 2.5.0
```

The SDK can still work at runtime because `_version.py` falls back to installed package metadata, but Speakeasy tracks this file as generated state. On the next generation, it expected the previous generated `_version.py` to be `2.5.1` and the new generated value to be `2.5.2`, while the repo still had `2.5.0`, so persistent edit merge failed with a conflict.

## Changes

- Align `src/mistralai/client/_version.py` with the current generated release version, `2.5.1`.
- Update the `Generate MISTRALAI` workflow's `align-version` job so it also aligns and stages `src/mistralai/client/_version.py` together with `pyproject.toml` and `uv.lock`.

## Validation

- `python -m py_compile src/mistralai/client/_version.py`
- Extracted the modified workflow shell block and ran `bash -n`
- `git diff --check`

## Follow-up

After this is merged, rerun the failed Python SDK generation workflow from a clean Speakeasy branch. Do not pre-create the `speakeasy/...` branch, because Speakeasy rejects auto branches containing manual commits.