### PR TITLE
chore: 🐝 Update SDK - Generate MISTRALAI MISTRALAI-SDK [speakeasy/mistralai-sdk-28798837538-1] 2.6.0

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,15 +5,15 @@ management:
   docVersion: 1.0.0
   speakeasyVersion: 1.763.6
   generationVersion: 2.884.13
-  releaseVersion: 2.5.2
-  configChecksum: 33e384241b239565493b89700a789dfb
+  releaseVersion: 2.6.0
+  configChecksum: 265ef64cad626b925e87e590fd62015b
   repoURL: https://github.com/mistralai/client-python.git
   installationURL: https://github.com/mistralai/client-python.git
   published: true
 persistentEdits:
-  generation_id: d5095a1f-4e5e-4f2f-b2f1-57400a61868d
-  pristine_commit_hash: 2dbde62172a6358ac855d7dc2c978759983ad57d
-  pristine_tree_hash: 235d1bf9fa33db32cf72571cb52b76a21c6acb86
+  generation_id: 71d6ff72-f01c-4350-a818-9a93edc88275
+  pristine_commit_hash: 8d9af16f101e54cc9439acf45b02370f78d7088c
+  pristine_tree_hash: c4c178abbd0886b6db32b6885223b86ce7596150
 features:
   python:
     acceptHeaders: 3.0.0
@@ -4197,8 +4197,8 @@ trackedFiles:
     pristine_git_object: 036d44b8cfc51599873bd5c401a6aed30450536c
   src/mistralai/client/_version.py:
     id: cc807b30de19
-    last_write_checksum: sha1:8286a689dafd9e1f69c1713849cec904c7fc14e3
-    pristine_git_object: 8a67baf0a961023d5129578ccd89a66b93a279e6
+    last_write_checksum: sha1:28275229a1c31218e058d217c62cf2b98e24ac01
+    pristine_git_object: b68b0487048782196a03347703a4f1e7eaf5019f
   src/mistralai/client/accesses.py:
     id: 76fc53bfcf59
     last_write_checksum: sha1:33d8a0663a647b7a7e1946064d05c3b40e538816

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -32,7 +32,7 @@ generation:
     generateNewTests: false
     skipResponseBodyAssertions: false
 python:
-  version: 2.5.2
+  version: 2.6.0
   additionalDependencies:
     dev:
       pytest: ^8.2.2

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -20,7 +20,7 @@ sources:
         sourceBlobDigest: sha256:293e895fc5dae852d73e3893db3843828c80fb136f03ce835d2c4cff122902ba
         tags:
             - latest
-            - speakeasy-mistralai-sdk-28652713237-1
+            - speakeasy-mistralai-sdk-28798837538-1
 targets:
     mistralai-azure-sdk:
         source: mistral-azure-source
@@ -42,7 +42,7 @@ targets:
         sourceRevisionDigest: sha256:b590d544f976dba688dfda05229cee0be00c376a9c3c209d527c1508ff0cb9da
         sourceBlobDigest: sha256:293e895fc5dae852d73e3893db3843828c80fb136f03ce835d2c4cff122902ba
         codeSamplesNamespace: mistral-openapi-code-samples
-        codeSamplesRevisionDigest: sha256:eabbb246bde91f082c4377dd5ad800b1fca2014a28c75d891bc292947649c138
+        codeSamplesRevisionDigest: sha256:324af77a787d4b6910a5ee12332fd3095a5ff7fcefe4a2d5aebcfea5935e353e
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: 1.763.6

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Mistral AI API: Our Chat Completion and Embeddings APIs specification. Create yo
   * [Resource Management](#resource-management)
   * [Debugging](#debugging)
   * [IDE Support](#ide-support)
-  * [Telemetry \& Observability](#telemetry--observability)
+  * [Telemetry & Observability](#telemetry-observability)
 * [Development](#development)
   * [Contributions](#contributions)
 
@@ -837,7 +837,7 @@ print(res.choices[0].message.content)
 operations. These operations will expose the stream as [Generator][generator] that
 can be consumed using a simple `for` loop. The loop will
 terminate when the server no longer has any events to send and closes the
-underlying connection.
+underlying connection.  
 
 The stream is also a [Context Manager][context-manager] and can be used with the `with` statement and will close the
 underlying connection when the context is exited.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -749,3 +749,13 @@ Based on:
 - [python v2.5.2] .
 ### Releases
 - [PyPI v2.5.2] https://pypi.org/project/mistralai/2.5.2 - .
+
+## 2026-07-06 14:27:15
+### Changes
+Based on:
+- OpenAPI Doc  
+- Speakeasy CLI 1.763.6 (2.884.13) https://github.com/speakeasy-api/speakeasy
+### Generated
+- [python v2.6.0] .
+### Releases
+- [PyPI v2.6.0] https://pypi.org/project/mistralai/2.6.0 - .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mistralai"
-version = "2.5.2"
+version = "2.6.0"
 description = "Python Client SDK for the Mistral AI API."
 authors = [{ name = "Mistral" }]
 requires-python = ">=3.10"

--- a/src/mistralai/client/_version.py
+++ b/src/mistralai/client/_version.py
@@ -4,10 +4,10 @@
 import importlib.metadata
 
 __title__: str = "mistralai"
-__version__: str = "2.5.2"
+__version__: str = "2.6.0"
 __openapi_doc_version__: str = "1.0.0"
 __gen_version__: str = "2.884.13"
-__user_agent__: str = "speakeasy-sdk/python 2.5.2 2.884.13 1.0.0 mistralai"
+__user_agent__: str = "speakeasy-sdk/python 2.6.0 2.884.13 1.0.0 mistralai"
 
 try:
     if __package__ is not None:

--- a/uv.lock
+++ b/uv.lock
@@ -1047,7 +1047,7 @@ wheels = [
 
 [[package]]
 name = "mistralai"
-version = "2.5.2"
+version = "2.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "eval-type-backport" },


### PR DESCRIPTION
# SDK update
## Versioning

Version Bump Type: [minor] - 🤖 (automated)

> [!TIP]
> If updates to your OpenAPI document introduce breaking changes, be sure to update the `info.version` field to [trigger the correct version bump](https://www.speakeasy.com/docs/sdks/manage/versioning#openapi-document-changes).
> Speakeasy supports manual control of SDK versioning through [multiple methods](https://www.speakeasy.com/docs/sdks/manage/versioning#manual-version-bumps).
<details>
<summary>OpenAPI Change Summary</summary>
No specification changes

[View full report](https://app.speakeasy.com/org/mistral-dev/mistral-dev/changes-report/e675711bf18cede70dc57b4a15942f6c)
</details>

<details>
<summary>Linting Report</summary>
0 errors, 6 warnings, 74 hints

[View full report](https://app.speakeasy.com/org/mistral-dev/mistral-dev/linting-report/0dbd0ee6963ec5110b0590bb7f523b18)
</details>

## PYTHON CHANGELOG
No relevant generator changes

<!-- execution_id: 019f37d3-827a-7d3d-b688-8ad790f1046a -->

Based on [Speakeasy CLI](https://github.com/speakeasy-api/speakeasy) 1.763.6
