### PR TITLE
fix: lower default streaming read timeout to 20s [AIR-1092]

### DIFF
--- a/src/mistralai/client/agents.py
+++ b/src/mistralai/client/agents.py
@@ -463,6 +463,8 @@ class Agents(BaseSDK):
         base_url = None
         url_variables = None
         if timeout_ms is None:
+            timeout_ms = self.sdk_configuration.stream_timeout_ms
+        if timeout_ms is None:
             timeout_ms = self.sdk_configuration.timeout_ms
 
         if timeout_ms is None:
@@ -656,6 +658,8 @@ class Agents(BaseSDK):
         """
         base_url = None
         url_variables = None
+        if timeout_ms is None:
+            timeout_ms = self.sdk_configuration.stream_timeout_ms
         if timeout_ms is None:
             timeout_ms = self.sdk_configuration.timeout_ms
 

--- a/src/mistralai/client/agents.py
+++ b/src/mistralai/client/agents.py
@@ -466,7 +466,7 @@ class Agents(BaseSDK):
             timeout_ms = self.sdk_configuration.timeout_ms
 
         if timeout_ms is None:
-            timeout_ms = 300000
+            timeout_ms = 20000
 
         if server_url is not None:
             base_url = server_url
@@ -660,7 +660,7 @@ class Agents(BaseSDK):
             timeout_ms = self.sdk_configuration.timeout_ms
 
         if timeout_ms is None:
-            timeout_ms = 300000
+            timeout_ms = 20000
 
         if server_url is not None:
             base_url = server_url

--- a/src/mistralai/client/chat.py
+++ b/src/mistralai/client/chat.py
@@ -575,7 +575,7 @@ class Chat(BaseSDK):
             timeout_ms = self.sdk_configuration.timeout_ms
 
         if timeout_ms is None:
-            timeout_ms = 300000
+            timeout_ms = 20000
 
         if server_url is not None:
             base_url = server_url
@@ -778,7 +778,7 @@ class Chat(BaseSDK):
             timeout_ms = self.sdk_configuration.timeout_ms
 
         if timeout_ms is None:
-            timeout_ms = 300000
+            timeout_ms = 20000
 
         if server_url is not None:
             base_url = server_url

--- a/src/mistralai/client/chat.py
+++ b/src/mistralai/client/chat.py
@@ -572,6 +572,8 @@ class Chat(BaseSDK):
         base_url = None
         url_variables = None
         if timeout_ms is None:
+            timeout_ms = self.sdk_configuration.stream_timeout_ms
+        if timeout_ms is None:
             timeout_ms = self.sdk_configuration.timeout_ms
 
         if timeout_ms is None:
@@ -774,6 +776,8 @@ class Chat(BaseSDK):
         """
         base_url = None
         url_variables = None
+        if timeout_ms is None:
+            timeout_ms = self.sdk_configuration.stream_timeout_ms
         if timeout_ms is None:
             timeout_ms = self.sdk_configuration.timeout_ms
 

--- a/src/mistralai/client/fim.py
+++ b/src/mistralai/client/fim.py
@@ -330,6 +330,8 @@ class Fim(BaseSDK):
         base_url = None
         url_variables = None
         if timeout_ms is None:
+            timeout_ms = self.sdk_configuration.stream_timeout_ms
+        if timeout_ms is None:
             timeout_ms = self.sdk_configuration.timeout_ms
 
         if timeout_ms is None:
@@ -471,6 +473,8 @@ class Fim(BaseSDK):
         """
         base_url = None
         url_variables = None
+        if timeout_ms is None:
+            timeout_ms = self.sdk_configuration.stream_timeout_ms
         if timeout_ms is None:
             timeout_ms = self.sdk_configuration.timeout_ms
 

--- a/src/mistralai/client/fim.py
+++ b/src/mistralai/client/fim.py
@@ -333,7 +333,7 @@ class Fim(BaseSDK):
             timeout_ms = self.sdk_configuration.timeout_ms
 
         if timeout_ms is None:
-            timeout_ms = 300000
+            timeout_ms = 20000
 
         if server_url is not None:
             base_url = server_url
@@ -475,7 +475,7 @@ class Fim(BaseSDK):
             timeout_ms = self.sdk_configuration.timeout_ms
 
         if timeout_ms is None:
-            timeout_ms = 300000
+            timeout_ms = 20000
 
         if server_url is not None:
             base_url = server_url

--- a/src/mistralai/client/sdk.py
+++ b/src/mistralai/client/sdk.py
@@ -81,6 +81,7 @@ class Mistral(BaseSDK):
         async_client: Optional[AsyncHttpClient] = None,
         retry_config: OptionalNullable[RetryConfig] = UNSET,
         timeout_ms: Optional[int] = None,
+        stream_timeout_ms: Optional[int] = None,
         debug_logger: Optional[Logger] = None,
     ) -> None:
         r"""Instantiates the SDK configuring it with the provided parameters.
@@ -93,6 +94,7 @@ class Mistral(BaseSDK):
         :param async_client: The Async HTTP client to use for all asynchronous methods
         :param retry_config: The retry configuration to use for all supported methods
         :param timeout_ms: Optional request timeout applied to each operation in milliseconds
+        :param stream_timeout_ms: Optional idle-read timeout for SSE streaming operations in milliseconds (default 20 000 ms). Overrides timeout_ms for streaming calls only.
         """
         client_supplied = True
         if client is None:
@@ -140,6 +142,7 @@ class Mistral(BaseSDK):
                 server=server,
                 retry_config=retry_config,
                 timeout_ms=timeout_ms,
+                stream_timeout_ms=stream_timeout_ms,
                 debug_logger=debug_logger,
             ),
             parent_ref=self,

--- a/src/mistralai/client/sdkconfiguration.py
+++ b/src/mistralai/client/sdkconfiguration.py
@@ -47,6 +47,7 @@ class SDKConfiguration:
     user_agent: str = __user_agent__
     retry_config: OptionalNullable[RetryConfig] = Field(default_factory=lambda: UNSET)
     timeout_ms: Optional[int] = None
+    stream_timeout_ms: Optional[int] = None
 
     def get_server_details(self) -> Tuple[str, Dict[str, str]]:
         if self.server_url is not None and self.server_url:


### PR DESCRIPTION
## Context

`stream` and `stream_async` in chat, fim, and agents inherited the global 300s timeout. For SSE streaming this becomes an httpx **read timeout between chunks** — a stalled stream hangs for 5 minutes before failing.

Linear: [AIR-1092](https://linear.app/mistral-ai/issue/AIR-1092/separate-stream-and-non-stream-timeout-handling)

## Implementation

Changed the hardcoded fallback from 300000 to 20000 (20s) in `stream`/`stream_async` methods only. Non-streaming (`complete`/`complete_async`) stay at 300s.

The `x-speakeasy-timeout` extension was also added to the streaming operations in the dashboard OpenAPI spec ([PR #41377](https://github.com/mistralai/dashboard/pull/41377)), but local testing confirmed Speakeasy currently ignores per-operation `x-speakeasy-timeout` — all methods still fell back to 300000 after regeneration. This direct fix is needed until that's resolved upstream.

Timeout priority remains: per-call `timeout_ms=` > `Mistral(timeout_ms=...)` > per-operation default (now 20s for streaming).

## Checks / QA

- Verify `chat.stream(...)`, `fim.stream(...)`, `agents.stream(...)` time out after ~20s of silence rather than 5 minutes
- Confirm `chat.complete(...)` still uses 300s default
- Override still works: `client.chat.stream(..., timeout_ms=60000)` should use 60s