### PR TITLE
chore: 🐝 Update SDK - Generate MISTRALAI MISTRALAI-SDK [speakeasy/mistralai-sdk-30366638574-1] 2.8.0

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,15 +5,15 @@ management:
   docVersion: 1.0.0
   speakeasyVersion: 1.763.6
   generationVersion: 2.884.13
-  releaseVersion: 2.7.2
-  configChecksum: f4cd446693dc9b60564bbce69007e60a
+  releaseVersion: 2.8.0
+  configChecksum: 0e14e5f78f084bd56361e365eb91e465
   repoURL: https://github.com/mistralai/client-python.git
   installationURL: https://github.com/mistralai/client-python.git
   published: true
 persistentEdits:
-  generation_id: 922290e1-f009-4ee8-9c3d-9d0425f9a5c5
-  pristine_commit_hash: fb321f1219d7cdc8cbd52c4d7fae2ef42a2b6b18
-  pristine_tree_hash: 2fc4647e7a81dfae8460c86e3e2187a0334bc5f4
+  generation_id: 57ac53f4-7a4c-47ab-a035-9d851ae1a22c
+  pristine_commit_hash: 5c904afc0e6ac09d0ff58e939908a0ddadf0f096
+  pristine_tree_hash: 79e2f1153f19968d5bf817f4cbb863cfd399edb5
 features:
   python:
     acceptHeaders: 3.0.0
@@ -4363,8 +4363,8 @@ trackedFiles:
     pristine_git_object: 036d44b8cfc51599873bd5c401a6aed30450536c
   src/mistralai/client/_version.py:
     id: cc807b30de19
-    last_write_checksum: sha1:eac49bcfbe0e31310c842b9e568f2ef7ef6cb246
-    pristine_git_object: e92bde75a3246a9185d461eddd3edd33d338c8d1
+    last_write_checksum: sha1:80b9ad2a551c2d632eec377adc10e13d70738eaa
+    pristine_git_object: 71442ec46af3e8322b1a56dd681924b6bed80349
   src/mistralai/client/accesses.py:
     id: 76fc53bfcf59
     last_write_checksum: sha1:33d8a0663a647b7a7e1946064d05c3b40e538816

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -32,7 +32,7 @@ generation:
     generateNewTests: false
     skipResponseBodyAssertions: false
 python:
-  version: 2.7.2
+  version: 2.8.0
   additionalDependencies:
     dev:
       pytest: ^8.2.2

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -20,7 +20,7 @@ sources:
         sourceBlobDigest: sha256:962e580a9814038b9f41f068c4a5f8b4d422a7962d35db0df435409e4e11b15a
         tags:
             - latest
-            - speakeasy-mistralai-sdk-30091961769-1
+            - speakeasy-mistralai-sdk-30366638574-1
 targets:
     mistralai-azure-sdk:
         source: mistral-azure-source
@@ -42,7 +42,7 @@ targets:
         sourceRevisionDigest: sha256:fd92984251174794ab0d1ec7c6017aefc443f6813027e8e1b1dbfaa320983e84
         sourceBlobDigest: sha256:962e580a9814038b9f41f068c4a5f8b4d422a7962d35db0df435409e4e11b15a
         codeSamplesNamespace: mistral-openapi-code-samples
-        codeSamplesRevisionDigest: sha256:2b64952e6de53ccfb8c3710065e13918b7944086c8f10ed2ed42c65f5917d24c
+        codeSamplesRevisionDigest: sha256:a3bf79f5a7244ad0b7fc3bb3b646f86ac1bd56a04c681c43e42c6818e905ae01
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: 1.763.6

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -789,3 +789,13 @@ Based on:
 - [python v2.7.2] .
 ### Releases
 - [PyPI v2.7.2] https://pypi.org/project/mistralai/2.7.2 - .
+
+## 2026-07-28 14:26:14
+### Changes
+Based on:
+- OpenAPI Doc  
+- Speakeasy CLI 1.763.6 (2.884.13) https://github.com/speakeasy-api/speakeasy
+### Generated
+- [python v2.8.0] .
+### Releases
+- [PyPI v2.8.0] https://pypi.org/project/mistralai/2.8.0 - .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mistralai"
-version = "2.7.2"
+version = "2.8.0"
 description = "Python Client SDK for the Mistral AI API."
 authors = [{ name = "Mistral" }]
 requires-python = ">=3.10"

--- a/src/mistralai/client/_version.py
+++ b/src/mistralai/client/_version.py
@@ -4,10 +4,10 @@
 import importlib.metadata
 
 __title__: str = "mistralai"
-__version__: str = "2.7.2"
+__version__: str = "2.8.0"
 __openapi_doc_version__: str = "1.0.0"
 __gen_version__: str = "2.884.13"
-__user_agent__: str = "speakeasy-sdk/python 2.7.2 2.884.13 1.0.0 mistralai"
+__user_agent__: str = "speakeasy-sdk/python 2.8.0 2.884.13 1.0.0 mistralai"
 
 try:
     if __package__ is not None:

--- a/uv.lock
+++ b/uv.lock
@@ -1047,7 +1047,7 @@ wheels = [
 
 [[package]]
 name = "mistralai"
-version = "2.7.2"
+version = "2.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "eval-type-backport" },


### PR DESCRIPTION
# SDK update
## Versioning

Version Bump Type: [minor] - 🤖 (automated)

> [!TIP]
> If updates to your OpenAPI document introduce breaking changes, be sure to update the `info.version` field to [trigger the correct version bump](https://www.speakeasy.com/docs/sdks/manage/versioning#openapi-document-changes).
> Speakeasy supports manual control of SDK versioning through [multiple methods](https://www.speakeasy.com/docs/sdks/manage/versioning#manual-version-bumps).
<details>
<summary>OpenAPI Change Summary</summary>
No specification changes

[View full report](https://app.speakeasy.com/org/mistral-dev/mistral-dev/changes-report/f35eb460d6cb7da377b4cc33d75d20ad)
</details>

<details>
<summary>Linting Report</summary>
0 errors, 6 warnings, 79 hints

[View full report](https://app.speakeasy.com/org/mistral-dev/mistral-dev/linting-report/38ab3ce45ea8ebf8e2557f6d92ab2486)
</details>

## PYTHON CHANGELOG
No relevant generator changes

<!-- execution_id: 019fa91e-7d22-7535-bef2-48f9c4fdb70d -->

Based on [Speakeasy CLI](https://github.com/speakeasy-api/speakeasy) 1.763.6
