### PR TITLE
perf(workflows): reuse S3 payload clients

### DIFF
--- a/src/mistralai/extra/tests/test_workflow_payload_client_pool.py
+++ b/src/mistralai/extra/tests/test_workflow_payload_client_pool.py
@@ -1,0 +1,193 @@
+"""Tests for the reusable S3 payload-offloading blob-storage client pool."""
+
+import unittest
+from typing import Any
+from unittest import mock
+
+from mistralai.extra.workflows.encoding.config import BlobStorageConfig, StorageProvider
+from mistralai.extra.workflows.encoding.storage import _s3 as s3_module
+from mistralai.extra.workflows.encoding.storage._s3 import S3BlobStorage
+from mistralai.extra.workflows.encoding.storage.blob_storage import (
+    _S3_STORAGE_CACHE,
+    close_cached_blob_storages,
+    get_blob_storage,
+)
+
+
+class _FakeS3Client:
+    def __init__(self, session: "_FakeSession") -> None:
+        self._session = session
+        self.entered = False
+        self.exited = False
+
+    async def __aenter__(self) -> "_FakeS3Client":
+        self.entered = True
+        self._session.client_enters += 1
+        return self
+
+    async def __aexit__(self, *_args: Any) -> None:
+        self.exited = True
+        self._session.client_exits += 1
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.clients_created = 0
+        self.client_enters = 0
+        self.client_exits = 0
+
+    def client(self, *_args: Any, **_kwargs: Any) -> _FakeS3Client:
+        self.clients_created += 1
+        return _FakeS3Client(self)
+
+
+def _s3_config(**overrides: Any) -> BlobStorageConfig:
+    values: dict[str, Any] = {
+        "storage_provider": StorageProvider.S3,
+        "bucket_name": "test-bucket",
+    }
+    values.update(overrides)
+    return BlobStorageConfig(**values)
+
+
+class ReuseClientConfigDefaultTest(unittest.TestCase):
+    def test_reuse_client_defaults_to_false(self) -> None:
+        assert "reuse_client" in BlobStorageConfig.model_fields
+        assert BlobStorageConfig().reuse_client is False
+        assert _s3_config().reuse_client is False
+
+
+class BlobStorageClientPoolTest(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        await close_cached_blob_storages()
+        self._session = _FakeSession()
+        patcher = mock.patch.object(
+            s3_module.aioboto3, "Session", return_value=self._session
+        )
+        self.addAsyncCleanup(close_cached_blob_storages)
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    async def test_reuse_client_false_creates_independent_clients(self) -> None:
+        config = _s3_config(reuse_client=False)
+
+        async with get_blob_storage(config) as first:
+            assert isinstance(first, S3BlobStorage)
+            first_client = first._client
+        async with get_blob_storage(config) as second:
+            assert isinstance(second, S3BlobStorage)
+            second_client = second._client
+
+        assert self._session.clients_created == 2
+        assert self._session.client_enters == 2
+        # Each non-reusing context closes its own client on exit.
+        assert self._session.client_exits == 2
+        assert first_client is not second_client
+        assert first is not second
+        assert not _S3_STORAGE_CACHE
+
+    async def test_reuse_client_true_reuses_single_client(self) -> None:
+        config = _s3_config(reuse_client=True)
+
+        async with get_blob_storage(config) as first:
+            assert isinstance(first, S3BlobStorage)
+            first_client = first._client
+        async with get_blob_storage(config) as second:
+            assert isinstance(second, S3BlobStorage)
+            second_client = second._client
+
+        assert self._session.clients_created == 1
+        assert self._session.client_enters == 1
+        # The reused client is kept open across contexts.
+        assert self._session.client_exits == 0
+        assert first is second
+        assert first_client is second_client
+        assert len(_S3_STORAGE_CACHE) == 1
+
+    async def test_reuse_client_true_distinct_configs_get_distinct_clients(self) -> None:
+        async with get_blob_storage(_s3_config(reuse_client=True)) as a:
+            pass
+        async with get_blob_storage(
+            _s3_config(reuse_client=True, bucket_name="other-bucket")
+        ) as b:
+            pass
+
+        assert a is not b
+        assert self._session.clients_created == 2
+        assert len(_S3_STORAGE_CACHE) == 2
+
+    async def test_close_cached_blob_storages_closes_and_is_repeatable(self) -> None:
+        async with get_blob_storage(_s3_config(reuse_client=True)) as storage:
+            assert isinstance(storage, S3BlobStorage)
+
+        assert storage._client is not None
+        assert self._session.client_exits == 0
+
+        await close_cached_blob_storages()
+
+        assert self._session.client_exits == 1
+        assert storage._client is None
+        assert not _S3_STORAGE_CACHE
+
+        # Repeated cleanup is a no-op and must not raise or double-close.
+        await close_cached_blob_storages()
+        assert self._session.client_exits == 1
+        assert not _S3_STORAGE_CACHE
+
+
+class BlobStorageClientLifecycleFailureTest(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        await close_cached_blob_storages()
+        self.addAsyncCleanup(close_cached_blob_storages)
+
+    async def test_enter_failure_surfaces_root_error(self) -> None:
+        boom = RuntimeError("connect failed")
+
+        class _FailingEnterCtx:
+            async def __aenter__(self) -> Any:
+                raise boom
+
+            async def __aexit__(self, *_args: Any) -> None:
+                return None
+
+        class _FailingEnterSession:
+            def client(self, *_args: Any, **_kwargs: Any) -> _FailingEnterCtx:
+                return _FailingEnterCtx()
+
+        with mock.patch.object(
+            s3_module.aioboto3, "Session", return_value=_FailingEnterSession()
+        ):
+            with self.assertRaises(RuntimeError) as caught:
+                async with get_blob_storage(_s3_config(reuse_client=True)):
+                    pass
+
+        assert caught.exception is boom
+        # A failed enter must not leave a half-open client cached.
+        assert not _S3_STORAGE_CACHE
+
+    async def test_exit_failure_surfaces_root_error(self) -> None:
+        boom = RuntimeError("teardown failed")
+
+        class _FailingExitClient:
+            async def __aenter__(self) -> "_FailingExitClient":
+                return self
+
+            async def __aexit__(self, *_args: Any) -> None:
+                raise boom
+
+        class _FailingExitSession:
+            def client(self, *_args: Any, **_kwargs: Any) -> _FailingExitClient:
+                return _FailingExitClient()
+
+        with mock.patch.object(
+            s3_module.aioboto3, "Session", return_value=_FailingExitSession()
+        ):
+            with self.assertRaises(RuntimeError) as caught:
+                async with get_blob_storage(_s3_config(reuse_client=False)):
+                    pass
+
+        assert caught.exception is boom
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/mistralai/extra/workflows/encoding/config.py
+++ b/src/mistralai/extra/workflows/encoding/config.py
@@ -13,6 +13,7 @@ class StorageProvider(str, Enum):
 class BlobStorageConfig(BaseModel):
     storage_provider: StorageProvider = StorageProvider.S3
     prefix: Optional[str] = None
+    reuse_client: bool = False
 
     # Azure settings
     container_name: Optional[str] = None

--- a/src/mistralai/extra/workflows/encoding/storage/_s3.py
+++ b/src/mistralai/extra/workflows/encoding/storage/_s3.py
@@ -17,6 +17,7 @@ class S3BlobStorage(BlobStorage):
         endpoint_url: str | None = None,
         aws_access_key_id: str | None = None,
         aws_secret_access_key: str | None = None,
+        reuse_client: bool = False,
     ):
         self.bucket_name = bucket_name
         self.prefix = prefix or ""
@@ -24,7 +25,9 @@ class S3BlobStorage(BlobStorage):
         self.endpoint_url = endpoint_url
         self.aws_access_key_id = aws_access_key_id
         self.aws_secret_access_key = aws_secret_access_key
+        self.reuse_client = reuse_client
         self._session: aioboto3.Session | None = None
+        self._client_context: Any = None
         self._client: Any = None
 
     def _get_full_key(self, key: str) -> str:
@@ -35,6 +38,8 @@ class S3BlobStorage(BlobStorage):
         return f"{self.prefix}/{key}"
 
     async def __aenter__(self) -> "S3BlobStorage":
+        if self._client is not None:
+            return self
         self._session = aioboto3.Session()
         assert self._session is not None
         kwargs: dict[str, Any] = {}
@@ -47,14 +52,21 @@ class S3BlobStorage(BlobStorage):
         if self.aws_secret_access_key:
             kwargs["aws_secret_access_key"] = self.aws_secret_access_key
 
-        self._client = self._session.client("s3", **kwargs)
-        self._client = await self._client.__aenter__()
+        self._client_context = self._session.client("s3", **kwargs)
+        self._client = await self._client_context.__aenter__()
         return self
 
     async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        if self._client:
-            await self._client.__aexit__(exc_type, exc_val, exc_tb)
+        if not self.reuse_client:
+            await self.aclose(exc_type, exc_val, exc_tb)
+
+    async def aclose(
+        self, exc_type: Any = None, exc_val: Any = None, exc_tb: Any = None
+    ) -> None:
+        if self._client_context is not None:
+            await self._client_context.__aexit__(exc_type, exc_val, exc_tb)
         self._session = None
+        self._client_context = None
         self._client = None
 
     async def upload_blob(self, key: str, content: bytes) -> str:

--- a/src/mistralai/extra/workflows/encoding/storage/blob_storage.py
+++ b/src/mistralai/extra/workflows/encoding/storage/blob_storage.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
+import sys
 from abc import ABC, abstractmethod
 from contextlib import asynccontextmanager
-from typing import Any, AsyncGenerator
+from typing import TYPE_CHECKING, Any, AsyncGenerator
 
 from mistralai.extra.workflows.encoding.config import BlobStorageConfig, StorageProvider
 from mistralai.extra.exceptions import WorkflowPayloadOffloadingException
+
+if TYPE_CHECKING:
+    from ._s3 import S3BlobStorage
+
+_S3_STORAGE_CACHE: dict[tuple[str | None, ...], "S3BlobStorage"] = {}
 
 
 class BlobNotFoundError(Exception):
@@ -59,6 +65,7 @@ async def get_blob_storage(
     """
     storage: BlobStorage
     prefix = blob_storage_config.prefix
+    cache_key: tuple[str | None, ...] | None = None
 
     if blob_storage_config.storage_provider == StorageProvider.AZURE:
         try:
@@ -116,30 +123,74 @@ async def get_blob_storage(
             raise WorkflowPayloadOffloadingException(
                 "bucket_name is required for S3 blob storage"
             )
-        storage = S3BlobStorage(
-            bucket_name=blob_storage_config.bucket_name,
-            prefix=prefix,
-            region_name=blob_storage_config.region_name,
-            endpoint_url=blob_storage_config.endpoint_url,
-            aws_access_key_id=(
-                blob_storage_config.aws_access_key_id.get_secret_value()
-                if blob_storage_config.aws_access_key_id
-                else None
-            ),
-            aws_secret_access_key=(
-                blob_storage_config.aws_secret_access_key.get_secret_value()
-                if blob_storage_config.aws_secret_access_key
-                else None
-            ),
+        access_key = (
+            blob_storage_config.aws_access_key_id.get_secret_value()
+            if blob_storage_config.aws_access_key_id
+            else None
         )
+        secret_key = (
+            blob_storage_config.aws_secret_access_key.get_secret_value()
+            if blob_storage_config.aws_secret_access_key
+            else None
+        )
+        if blob_storage_config.reuse_client:
+            cache_key = (
+                blob_storage_config.bucket_name,
+                prefix,
+                blob_storage_config.region_name,
+                blob_storage_config.endpoint_url,
+                access_key,
+                secret_key,
+            )
+            storage = _S3_STORAGE_CACHE.get(cache_key) or S3BlobStorage(
+                bucket_name=blob_storage_config.bucket_name,
+                prefix=prefix,
+                region_name=blob_storage_config.region_name,
+                endpoint_url=blob_storage_config.endpoint_url,
+                aws_access_key_id=access_key,
+                aws_secret_access_key=secret_key,
+                reuse_client=True,
+            )
+            _S3_STORAGE_CACHE[cache_key] = storage
+        else:
+            storage = S3BlobStorage(
+                bucket_name=blob_storage_config.bucket_name,
+                prefix=prefix,
+                region_name=blob_storage_config.region_name,
+                endpoint_url=blob_storage_config.endpoint_url,
+                aws_access_key_id=access_key,
+                aws_secret_access_key=secret_key,
+                reuse_client=False,
+            )
 
     else:
         raise ValueError(
             f"Unsupported storage provider: {blob_storage_config.storage_provider}"
         )
 
-    async with storage as blob_storage_instance:
-        yield blob_storage_instance
+    try:
+        entered = await storage.__aenter__()
+    except BaseException:
+        # A pooled client that never finished entering must not stay cached.
+        if cache_key is not None:
+            _S3_STORAGE_CACHE.pop(cache_key, None)
+        raise
+    try:
+        yield entered
+    finally:
+        await storage.__aexit__(*sys.exc_info())
 
 
-__all__ = ["BlobStorage", "BlobNotFoundError", "get_blob_storage"]
+async def close_cached_blob_storages() -> None:
+    storages = list(_S3_STORAGE_CACHE.values())
+    _S3_STORAGE_CACHE.clear()
+    for storage in storages:
+        await storage.aclose()
+
+
+__all__ = [
+    "BlobStorage",
+    "BlobNotFoundError",
+    "close_cached_blob_storages",
+    "get_blob_storage",
+]


### PR DESCRIPTION
## Summary

Adds an opt-in reusable S3 client for workflow payload offloading so a worker can reuse a single `aioboto3` S3 client across many offload/reload calls instead of opening (and tearing down) a new client for every payload.

- `BlobStorageConfig.reuse_client` (default `False`) — fully backward compatible; the current per-context client behavior is unchanged unless a caller opts in.
- When `reuse_client=True`, `get_blob_storage` pools one `S3BlobStorage` per safe key `(bucket_name, prefix, region_name, endpoint_url, access_key, secret_key)`, so repeated contexts for the same destination share one open client.
- `S3BlobStorage` now tracks its client context explicitly (`_client_context`), returns early from `__aenter__` when a client is already open, and only tears down on `__aexit__` when it is not reusing. Real teardown lives in `aclose(...)`.
- `close_cached_blob_storages()` closes every pooled client and is safe to call repeatedly (idempotent) — intended for worker shutdown.
- A client that fails to enter is never left half-open in the pool, and context exit still forwards the original exception (faithful to `async with`).

Scope is intentionally minimal: only the reusable-client mechanism is added. No caching layer, no HEAD/existence-check changes, no other config fields.

## Changes

- `src/mistralai/extra/workflows/encoding/config.py`: add `reuse_client: bool = False`.
- `src/mistralai/extra/workflows/encoding/storage/_s3.py`: explicit client-context tracking, reuse guard, `aclose`, reuse-aware `__aexit__`.
- `src/mistralai/extra/workflows/encoding/storage/blob_storage.py`: keyed S3 client pool, reuse-aware construction, `close_cached_blob_storages`, safe enter/exit lifecycle.
- `src/mistralai/extra/tests/test_workflow_payload_client_pool.py`: new tests.

All edited files are hand-owned (listed in `.genignore`); no generated SDK surface is touched.

## Verification

- New tests: `test_workflow_payload_client_pool.py` — default `False`, independent clients when disabled, single client reuse when enabled, distinct clients per distinct reuse config, repeatable cleanup, and enter/exit failure lifecycle (root error preserved, no cache leak).
- `uv run python -m unittest discover -s src/mistralai/extra/tests -t src` — 152 passed (CI path).
- `uv run pytest tests/` — 358 passed, 46 skipped.
- `uv run ruff check src/mistralai/extra/` — clean.
- `uv run --all-extras mypy src/mistralai/extra/` — clean.
- `uv run --all-extras pyright src/mistralai/extra/` — 0 errors.
- `uv build` — sdist + wheel build successfully.
- `git diff --check` — clean.
- Isolated fake-`aioboto3` manual QA (no network) proving creation counts and cleanup: `reuse_client=False` → 2 clients for 2 contexts; `reuse_client=True` → 1 client kept open; `close_cached_blob_storages()` closes once and is idempotent; enter/exit failures surface the root error; repeated interruptions leave the pool stable.
