### PR TITLE
fix(otel): relax semantic-conventions upper bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "python-dateutil >=2.8.2",
     "typing-inspection >=0.4.0",
     "opentelemetry-api (>=1.33.1,<2.0.0)",
-    "opentelemetry-semantic-conventions (>=0.60b1,<0.61)",
+    "opentelemetry-semantic-conventions (>=0.60b1)",
     "jsonpath-python >=1.0.6", # required for speakeasy generated path with pagination
 ]
 
@@ -68,7 +68,7 @@ dev = [
     "pyyaml>=6.0.2,<7",
     "mypy==1.15.0",
     "msgpack>=1.1.0,<2.0.0",
-    "opentelemetry-instrumentation-httpx (>=0.60b1,<0.61)",
+    "opentelemetry-instrumentation-httpx (>=0.60b1)",
     "opentelemetry-sdk (>=1.33.1,<2.0.0)",
     "opentelemetry-exporter-otlp-proto-http (>=1.33.1,<2.0.0)",
     "pylint==3.2.3",

--- a/src/mistralai/client/_hooks/traceparent.py
+++ b/src/mistralai/client/_hooks/traceparent.py
@@ -12,6 +12,19 @@ _EXECUTE_OPERATION_IDS = {
     "execute_workflow_registration_v1_workflows_registrations__workflow_registration_id__execute_post",
 }
 
+_SAMPLED_FLAG = 0x01
+
+
+# https://www.w3.org/TR/trace-context/#traceparent-header
+def _is_sampled(traceparent: str) -> bool:
+    parts = traceparent.split("-")
+    if len(parts) != 4:
+        return False
+    try:
+        return bool(int(parts[3], 16) & _SAMPLED_FLAG)
+    except ValueError:
+        return False
+
 
 class TraceparentInjectionHook(BeforeRequestHook):
     """Inject a sampled traceparent on /execute requests so worker traces are always recorded."""
@@ -29,7 +42,7 @@ class TraceparentInjectionHook(BeforeRequestHook):
         carrier: Dict[str, str] = {}
         inject(carrier)
         traceparent = carrier.get("traceparent", "")
-        if not traceparent.endswith("-01"):
+        if not _is_sampled(traceparent):
             trace_id = random.getrandbits(128)
             span_id = random.getrandbits(64)
             traceparent = f"00-{trace_id:032x}-{span_id:016x}-01"

--- a/src/mistralai/extra/tests/test_traceparent_hook.py
+++ b/src/mistralai/extra/tests/test_traceparent_hook.py
@@ -86,7 +86,7 @@ class TestTraceparentInjectionHook(unittest.TestCase):
 
         assert isinstance(result, httpx.Request)
         injected = result.headers["traceparent"]
-        self.assertTrue(injected.endswith("-01"))
+        self.assertTrue(int(injected.split("-")[3], 16) & 0x01)
         trace_id_hex = f"{span.get_span_context().trace_id:032x}"
         self.assertIn(trace_id_hex, injected)
 


### PR DESCRIPTION
## Why

`opentelemetry-semantic-conventions (>=0.60b1,<0.61)` capped the whole OpenTelemetry stack for downstream consumers, not just semconv.

OTel ships semconv and the `instrumentation-*` packages as a lockstep set pinned with `==`, and semconv itself requires an exact api version:

```
opentelemetry-semantic-conventions 0.65b0 -> ['opentelemetry-api==1.44.0', ...]
opentelemetry-sdk 1.44.0                  -> ['opentelemetry-semantic-conventions==0.65b0', ...]
```

So `<0.61` held consumers' `opentelemetry-api` and `-sdk` at the 1.39.x generation. A floor keeps the caution without letting a library dictate the application's whole observability stack.

## Changes

| File | Change |
|---|---|
| `pyproject.toml` | ceiling → floor on `semantic-conventions` and `instrumentation-httpx` |
| `_hooks/traceparent.py` | sampled-flag check is now a bitmask test |
| `tests/test_traceparent_hook.py` | assertion follows suit |

## The bug the cap was hiding

W3C trace-context level 2 adds `RANDOM_TRACE_ID = 0x02`, so from `opentelemetry-api` 1.44.0 a sampled span serializes as `-03`, not `-01`:

```python
if not traceparent.endswith("-01"):     # reads "-03" as unsampled
    trace_id = random.getrandbits(128)  # discards the real context
```

Every workflow `/execute` call would silently start a new trace, orphaning worker traces from their caller. Latent today only because the cap kept api at 1.39.1, so relaxing the cap without this fix would ship the regression.

## Verification

- All 39 semconv symbols the SDK references resolve in both 0.60b1 and 0.65b0, and every resolved value is byte-identical — no attribute names shift.
- Full `extra` suite: 260 passed on semconv 0.60b1 / api 1.39.1 and on 0.65b0 / api 1.44.0, so the floor stays genuinely supported rather than just the ceiling raised.
- `ruff` and `mypy` clean.

## Note on generated code

`pyproject.toml` is listed in `.genignore`, and none of the three files appear in `gen.lock`'s tracked manifest, so no `gen.yaml` change is needed. I could not complete `speakeasy run` locally — it aborts during source validation, identically on a pristine tree — so that is worth confirming on a CI generation run.