### PR TITLE
ci: publish with a twine that accepts current wheel metadata

### DIFF
--- a/.github/workflows/sdk_publish_mistralai_sdk.yaml
+++ b/.github/workflows/sdk_publish_mistralai_sdk.yaml
@@ -42,7 +42,7 @@ jobs:
           uv build --sdist --wheel --out-dir dist/mistralai
 
       - name: Publish mistralai to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: dist/mistralai/
           print-hash: true


### PR DESCRIPTION
## Context

`mistralai 2.9.4` did not reach PyPI. The publish job failed with:

```
Checking dist/mistralai/mistralai-2.9.4-py3-none-any.whl:
ERROR InvalidDistribution: Invalid distribution metadata:
      '2.5' is not a valid metadata version
```

The wheel is fine. The uploader is out of date.

`setup-uv` installs the newest uv unless a version is declared, and the log says so: "Could not determine uv version from uv.toml or pyproject.toml. Falling back to latest." The publish on 13 August used uv 0.12.3, this one used 0.12.5, and 0.12.5 writes `Metadata-Version: 2.5`. That is a valid, current format. The action pinned here bundles `twine==6.1.0`, which predates it.

Nothing in this repository changed. One side moved, the other is frozen.

## Implementation

Bump the publish action to the first tag whose bundled twine understands the format:

| tag | twine |
| --- | --- |
| v1.13.0 (current) | 6.1.0 |
| v1.14.0 | 6.1.0 |
| v1.14.1 | 6.1.0 |
| v1.14.2 | 7.0.0 |

Pinning uv instead was the other option and is worse: it freezes a correct tool to satisfy a stale one, blocks every later uv improvement, and has to be maintained by hand. Metadata versions are a slow standardised sequence and a current twine reads current and older wheels, so moving the uploader forward is the durable direction.

`dashboard` already runs v1.14.2 in five of its publish workflows, so this brings the SDK in line rather than introducing anything new.

## Checks / QA

Reproduced and verified locally rather than inferred. Building a trivial package with uv 0.12.5 produces `Metadata-Version: 2.5`, and checking that same wheel:

```
twine 6.1.0  ->  ERROR: '2.5' is not a valid metadata version
twine 7.0.0  ->  PASSED
```

The four inputs this workflow passes (`packages-dir`, `print-hash`, `verbose`, `skip-existing`) all still exist in v1.14.2.

The real test is the next publish reaching PyPI. Version 2.9.4 was never uploaded, so nothing needs yanking and the next run should pick it up cleanly.
