### PR TITLE
chore: bump Speakeasy to 1.796.1

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,5 +1,5 @@
 workflowVersion: 1.0.0
-speakeasyVersion: 1.763.6
+speakeasyVersion: 1.796.1
 sources:
     mistral-azure-source:
         inputs:


### PR DESCRIPTION
Bumps the generator pin from `1.763.6`, which was three months old.

Keeps the Python and TypeScript SDKs on the same generator version.

For Python this also picks up a fix to the generated retry loop: a retried streaming request previously kept its response open across the backoff, so the connection stayed checked out and the pool could exhaust. Tracked in https://github.com/mistralai/client-python/issues/532.

No source changes here, the pin only. Regeneration follows separately.