### PR TITLE
chore: bump Speakeasy to 1.796.4

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,5 +1,5 @@
 workflowVersion: 1.0.0
-speakeasyVersion: 1.796.1
+speakeasyVersion: 1.796.4
 sources:
     mistral-azure-source:
         inputs:


### PR DESCRIPTION
Bumps the generator pin from `1.796.1`.

Picks up the TypeScript SSE overload fix in `1.796.4`, so both clients can sit on the same generator version again.

Pin only, no generated output.